### PR TITLE
Fixed Issue 31, made memoization optional, updated regex deps for Clojars

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Compiling uap-clj.java.api.browser
 Compiling uap-clj.java.api.device
 Compiling uap-clj.java.api.os
 Compiling uap-clj.os
-Created /Users/<username>/dev/uap-clj/target/uap-clj-1.2.2.jar
-Created /Users/<username>/dev/uap-clj/target/uap-clj-1.2.2-standalone.jar
+Created /Users/<username>/dev/uap-clj/target/uap-clj-1.3.0.jar
+Created /Users/<username>/dev/uap-clj/target/uap-clj-1.3.0-standalone.jar
 ```
 
 ### Java dependencies
@@ -43,9 +43,9 @@ Java(TM) SE Runtime Environment (build 1.7.0_51-b13)
 Java HotSpot(TM) 64-Bit Server VM (build 24.51-b03, mixed mode)
 
 → java -version
-java version "1.8.0_66"
-Java(TM) SE Runtime Environment (build 1.8.0_66-b17)
-Java HotSpot(TM) 64-Bit Server VM (build 25.66-b17, mixed mode)
+java version "1.8.0_102"
+Java(TM) SE Runtime Environment (build 1.8.0_102-b14)
+Java HotSpot(TM) 64-Bit Server VM (build 25.102-b14, mixed mode)
 ```
 
 ## Development
@@ -56,17 +56,19 @@ This project uses [`speclj`](http://speclj.com). The core test suite comprises a
 ```bash
 → lein test
 
-Ran 53842 tests containing 53842 assertions.
-0 failures, 0 errors.
+Finished in 0.29424 seconds
+108349 examples, 0 failures
 ```
 The test suite runs against all the browser, o/s, and device YAML fixtures in [`ua-parser/uap-core/tests`](https://github.com/ua-parser/uap-core/blob/master/tests), for both the native Clojure core library and the Java API.
 
-## Use
+## Use / Production
+
+The basic utility functions of this library comprise `useragent`, `browser`, `os`, and `device`; memoized versions of the same functions are provided as conveniences for production environments where a requirement for low latency response from large numbers of rapidly repeated requests is worth the memory penalty incurred by the need to maintain a growing cache of input/output value mappings. Accordingly, these functions are named `useragent-memoized`, `browser-memoized`, `os-memoized`, and `device-memoized`.
 
 ### Commandline (CLI)
 
 ```bash
-/usr/bin/java -jar uap-clj-1.2.2-standalone.jar <input_filename> [<optional_out_filename>]
+/usr/bin/java -jar uap-clj-1.3.0-standalone.jar <input_filename> [<optional_out_filename>]
 ```
 
 This command takes as its first argument the name of a text file containing one useragent per line, and prints a TSV (tab-separated) file - defaulting to `useragent_lookup.tsv` - with this line format:
@@ -92,7 +94,7 @@ If you'd like to explore useragent data interactively, and you have Leiningen in
 nREPL server started on port 51929 on host 127.0.0.1 - nrepl://127.0.0.1:51929
 REPL-y 0.3.7, nREPL 0.2.12
 Clojure 1.8.0
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_66-b17
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_102-b14
     Docs: (doc function-name-here)
           (find-doc "part-of-name-here")
   Source: (source function-name-here)
@@ -166,7 +168,7 @@ If you have an Heroku account, [you can easily deploy a Compojure app there](htt
   (ANY "*" []
        (route/not-found (slurp (io/resource "404.html")))))
 ```
-All you need to enable the use of the `lookup-useragent` function here is to add `[uap-clj "1.2.2"]` to the `:dependencies` vector in your Compojure app's `project.clj`, and `[uap-clj.core :refer [lookup-useragent]]` to the `:require` vector of your `web.clj`. Then you can do this type of thing after deployment:
+All you need to enable the use of the `lookup-useragent` function here is to add `[uap-clj "1.3.0"]` to the `:dependencies` vector in your Compojure app's `project.clj`, and `[uap-clj.core :refer [lookup-useragent]]` to the `:require` vector of your `web.clj`. Then you can do this type of thing after deployment:
 
 ```bash
 → curl --data "ua=AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)" http://<your_app>.herokuapp.com {:ua "AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)", :browser {:family "Other", :patch nil, :major nil, :minor nil}, :os {:family "ATV OS X", :major "", :minor "", :patch "", :patch_minor ""}, :device {:family "AppleTV", :brand "Apple", :model "AppleTV"}}
@@ -194,7 +196,7 @@ Then add these dependencies to your `pom.xml`:
 <dependency>
   <groupId>uap-clj</groupId>
   <artifactId>uap-clj</artifactId>
-  <version>1.2.2</version>
+  <version>1.3.0</version>
 </dependency>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject uap-clj "1.2.2"
+(defproject uap-clj "1.3.0"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/russellwhitaker/uap-clj"
   :license {:name "The MIT License (MIT)"
@@ -18,7 +18,7 @@
                          [#"dev_resources|^test$|test_resources|docs|\.md|LICENSE"]}}
   :plugins [[lein-git-deps   "0.0.2"]
             [lein-ancient    "0.6.10"]
-            [lein-bikeshed   "0.3.0"]
+            [lein-bikeshed   "0.4.1"]
             [jonase/eastwood "0.2.3"]
             [speclj          "3.3.2"]]
   :git-dependencies [["https://github.com/ua-parser/uap-core.git"]]

--- a/spec/uap_clj/browser_spec.clj
+++ b/spec/uap_clj/browser_spec.clj
@@ -39,6 +39,12 @@
 (context "Known Browsers:"
   (map #(run-browser-fixture %) tests))
 
+(context "nil input"
+  (describe "graceful handling"
+    (it "returns default map with nil values"
+      (should= {:family nil :major nil :minor nil :patch nil}
+               (browser nil)))))
+
 ;;;
 ;;; The ua-parser core specification requires setting browser family to "Other"
 ;;;   and major, minor, & patch numbers to nothing if an unfamiliar

--- a/spec/uap_clj/core_spec.clj
+++ b/spec/uap_clj/core_spec.clj
@@ -1,0 +1,51 @@
+(ns uap-clj.core-spec
+  "Tests for limited bad input edge cases for core
+   'useragent' function. Exhaustive (generative) testing
+   for the os, device, and browser functions - which 'useragent'
+   calls - are found in their own specs.
+  "
+  (:require [speclj.core :refer :all]
+            [uap-clj.common-spec :refer [unknown-ua]]
+            [uap-clj.core :refer [useragent]]))
+
+(context "nil input"
+  (describe "graceful handling"
+    (it "returns default map with nil values"
+      (should= {:ua nil
+                :browser
+                  {:family nil
+                   :major nil
+                   :minor nil
+                   :patch nil}
+                :os
+                  {:family nil
+                   :major nil
+                   :minor nil
+                   :patch nil
+                   :patch_minor nil}
+                :device
+                  {:family nil
+                   :brand nil
+                   :model nil}}
+               (useragent nil)))))
+
+(context "Unknown useragent"
+ (describe "graceful handling"
+   (it "returns default map with 'Other' classification"
+     (should= {:ua "Crazy new useragent in the wild/v0.1.0"
+               :browser
+                 {:family "Other"
+                  :major nil
+                  :minor nil
+                  :patch nil}
+               :os
+                 {:family "Other"
+                  :major nil
+                  :minor nil
+                  :patch nil
+                  :patch_minor nil}
+               :device
+                 {:family "Other"
+                  :brand nil
+                  :model nil}}
+              (useragent unknown-ua)))))

--- a/spec/uap_clj/device_spec.clj
+++ b/spec/uap_clj/device_spec.clj
@@ -36,6 +36,12 @@
 (context "Known Device:"
   (map #(run-device-fixture %) tests))
 
+(context "nil input"
+  (describe "graceful handling"
+    (it "returns default map with nil values"
+      (should= {:family nil :brand nil :model nil}
+               (device nil)))))
+
 ;;;
 ;;; The ua-parser core specification requires setting device family to "Other"
 ;;;   and brand & model to nothing if an unfamiliar (i.e. not in regexes.yaml)

--- a/spec/uap_clj/os_spec.clj
+++ b/spec/uap_clj/os_spec.clj
@@ -44,6 +44,12 @@
 (context "Known O/S:"
   (map #(run-os-fixture %) tests))
 
+(context "nil input"
+  (describe "graceful handling"
+    (it "returns default map with nil values"
+      (should= {:family nil :major nil :minor nil :patch nil :patch_minor nil}
+               (os nil)))))
+
 ;;;
 ;;; The ua-parser core specification requires setting o/s family to "Other"
 ;;;   and major, minor, patch, and patch minor numbers to nothing if

--- a/src/uap_clj/browser.clj
+++ b/src/uap_clj/browser.clj
@@ -7,19 +7,21 @@
 
 (def regexes (:user_agent_parsers regexes-all))
 
-(def browser
-  (memoize
-    (fn
-      [ua]
-      (try
-        (let [match (first-match ua regexes)
-              result (first (flatten (vector (:result match))))]
-          (if (= "Other" result)
-            {:family "Other" :major nil :minor nil :patch nil}
-            (let [family (field match :family_replacement 1)
-                  major (field match :v1_replacement 2)
-                  minor (field match :v2_replacement 3)
-                  patch (field match :v3_replacement 4)]
-              {:family family :major major :minor minor :patch patch})))
-      (catch java.lang.IndexOutOfBoundsException e
-        {:family "Other" :major nil :minor nil :patch nil})))))
+(defn browser
+  [ua]
+  (try
+    (let [match (first-match ua regexes)
+          result (first (flatten (vector (:result match))))]
+      (if (= "Other" result)
+        {:family "Other" :major nil :minor nil :patch nil}
+        (let [family (field match :family_replacement 1)
+              major (field match :v1_replacement 2)
+              minor (field match :v2_replacement 3)
+              patch (field match :v3_replacement 4)]
+          {:family family :major major :minor minor :patch patch})))
+  (catch java.lang.IndexOutOfBoundsException e
+    {:family "Other" :major nil :minor nil :patch nil})))
+
+; For use in production settings where speed may be preferred
+;  in exchange for the tradeoff of increased memory bloat:
+(def browser-memoized (memoize browser))

--- a/src/uap_clj/core.clj
+++ b/src/uap_clj/core.clj
@@ -22,14 +22,21 @@
                  [(base-config)
                   (local-config)])))
 
-(def useragent
-  (memoize
-    (fn
-      [line]
-      {:ua line
-       :browser (browser line)
-       :os (os line)
-       :device (device line)})))
+(defn useragent
+  "Look up all 3 sets of fields for:
+   - browser
+   - o/s
+   - device
+  "
+  [ua]
+  {:ua ua
+   :browser (browser ua)
+   :os (os ua)
+   :device (device ua)})
+
+; For use in production settings where speed may be preferred
+;  in exchange for the tradeoff of increased memory bloat:
+(def useragent-memoized (memoize useragent))
 
 (def cfg (config))
 (def columns (:output-columns cfg))

--- a/src/uap_clj/device.clj
+++ b/src/uap_clj/device.clj
@@ -7,18 +7,20 @@
 
 (def regexes (:device_parsers regexes-all))
 
-(def device
-  (memoize
-    (fn
-      [ua]
-      (try
-        (let [match (first-match ua regexes)
-             result (first (flatten (vector (:result match))))]
-          (if (= "Other" result)
-            {:family "Other" :brand nil :model nil}
-            (let [family (field match :device_replacement 1)
-                  brand (field match :brand_replacement 2)
-                  model (field match :model_replacement 1)]
-              {:family family :brand brand :model model})))
-      (catch java.lang.IndexOutOfBoundsException e
-        {:family "Other" :brand nil :model nil})))))
+(defn device
+  [ua]
+  (try
+    (let [match (first-match ua regexes)
+          result (first (flatten (vector (:result match))))]
+      (if (= "Other" result)
+        {:family "Other" :brand nil :model nil}
+        (let [family (field match :device_replacement 1)
+              brand (field match :brand_replacement 2)
+              model (field match :model_replacement 1)]
+          {:family family :brand brand :model model})))
+  (catch java.lang.IndexOutOfBoundsException e
+    {:family "Other" :brand nil :model nil})))
+
+; For use in production settings where speed may be preferred
+;  in exchange for the tradeoff of increased memory bloat:
+(def device-memoized (memoize device))

--- a/src/uap_clj/os.clj
+++ b/src/uap_clj/os.clj
@@ -7,28 +7,30 @@
 
 (def regexes (:os_parsers regexes-all))
 
-(def os
-  (memoize
-    (fn
-      [ua]
-      (try
-        (let [match (first-match ua regexes)
-             result (first (flatten (vector (:result match))))]
-          (if (= "Other" result)
-            {:family "Other" :major nil :minor nil :patch nil :patch_minor nil}
-            (let [family (field match :os_replacement 1)
-                  major (field match :os_v1_replacement 2)
-                  minor (field match :os_v2_replacement 3)
-                  patch (field match :os_v3_replacement 4)
-                  patch-minor (field match :os_v4_replacement 5)]
-              {:family family
-               :major major
-               :minor minor
-               :patch patch
-              :patch_minor patch-minor})))
-      (catch java.lang.IndexOutOfBoundsException e
-        {:family "Other"
-         :major nil
-         :minor nil
-         :patch nil
-         :patch_minor nil})))))
+(defn os
+  [ua]
+  (try
+    (let [match (first-match ua regexes)
+          result (first (flatten (vector (:result match))))]
+      (if (= "Other" result)
+        {:family "Other" :major nil :minor nil :patch nil :patch_minor nil}
+        (let [family (field match :os_replacement 1)
+              major (field match :os_v1_replacement 2)
+              minor (field match :os_v2_replacement 3)
+              patch (field match :os_v3_replacement 4)
+              patch-minor (field match :os_v4_replacement 5)]
+          {:family family
+           :major major
+           :minor minor
+           :patch patch
+          :patch_minor patch-minor})))
+  (catch java.lang.IndexOutOfBoundsException e
+    {:family "Other"
+     :major nil
+     :minor nil
+     :patch nil
+     :patch_minor nil})))
+
+; For use in production settings where speed may be preferred
+;  in exchange for the tradeoff of increased memory bloat:
+(def os-memoized (memoize os))


### PR DESCRIPTION
Belatedly fixes https://github.com/russellwhitaker/uap-clj/issues/31 filed by @arichiardi and implements a good suggestion by @arr-ee to make un-memoized versions of the core API the actual default, while providing the memoized versions if needed.