### PR TITLE
Replace archived version of clj-yaml dep with clj-commons version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,9 +5,9 @@
             :url "http://www.opensource.org/licenses/mit-license.php"}
   :scm {:name "git"
         :url "https://github.com/russellwhitaker/uap-clj"}
-  :dependencies [[org.clojure/clojure      "1.8.0"]
+  :dependencies [[org.clojure/clojure      "1.10.0"]
                  [russellwhitaker/immuconf "0.3.0"]
-                 [circleci/clj-yaml        "0.5.6"]]
+                 [clj-commons/clj-yaml     "0.6.0"]]
   :profiles {:dev
               {:dependencies [[criterium "0.4.4"]
                               [speclj    "3.3.2"]]


### PR DESCRIPTION
The circle-ci/clj-yaml repository has been archived (https://github.com/circleci/clj-yaml#this-respository-was-originally-a-fork-of-the-original-and-is-no-longer-being-maintained-the-project-is-now-a-part-of-clj-commons)

and ownership has moved to clj-commons.

The tests all passed after the dependency updates.