### PR TITLE
Prepare 1.8.0 release: add deps.edn/build.clj, update CI workflow, bump version

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -21,6 +21,7 @@ jobs:
       uses: DeLaGuardo/setup-clojure@13.5.2
       with:
         cli: latest
+        lein: 2.9.1
     - name: Check for outdated dependencies
       run: clojure -T:build outdated
     - name: Install dependencies

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -14,8 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6.0.2
+      with:
+        submodules: recursive
+    - name: Check for outdated dependencies
+      run: clojure -T:build outdated
     - name: Install dependencies
-      run: lein deps
+      run: rm -rf .lein-git-deps && lein git-deps && lein deps
     - name: Run tests
       run: lein test

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -17,6 +17,10 @@ jobs:
     - uses: actions/checkout@v6.0.2
       with:
         submodules: recursive
+    - name: Install Clojure Tools
+      uses: DeLaGuardo/setup-clojure@13.5.2
+      with:
+        cli: latest
     - name: Check for outdated dependencies
       run: clojure -T:build outdated
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pom.xml.asc
 output.tsv
 **/.private/
 .clj-kondo/
+.cpcache/

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ To generate your classes and .jar files:
 
 ```console
 $ lein build
-Created [...]/uap-clj/target/uap-clj-1.7.1.jar
-Created [...]/uap-clj/target/uap-clj-1.7.1-standalone.jar
+Created [...]/uap-clj/target/uap-clj-1.8.0.jar
+Created [...]/uap-clj/target/uap-clj-1.8.0-standalone.jar
 ```
 
 ### Java dependencies
@@ -85,7 +85,7 @@ The basic utility functions of this library comprise `useragent`, `browser`, `os
 ### Commandline (CLI)
 
 ```bash
-/usr/bin/java -jar uap-clj-1.7.1-standalone.jar <input_filename> [<optional_out_filename>]
+/usr/bin/java -jar uap-clj-1.8.0-standalone.jar <input_filename> [<optional_out_filename>]
 ```
 
 This command takes as its first argument the name of a text file containing one useragent per line, and prints a TSV (tab-separated) file - defaulting to `useragent_lookup.tsv` - with this line format:
@@ -108,10 +108,10 @@ If you'd like to explore useragent data interactively, and you have Leiningen in
 
 ```clojure
 $ lein repl
-nREPL server started on port 54100 on host 127.0.0.1 - nrepl://127.0.0.1:54100
-REPL-y 0.4.4, nREPL 0.8.3
-Clojure 1.11.1
-OpenJDK 64-Bit Server VM 17.0.7+7
+nREPL server started on port 62340 on host 127.0.0.1 - nrepl://127.0.0.1:62340
+REPL-y 0.5.1, nREPL 1.0.0
+Clojure 1.12.4
+OpenJDK 64-Bit Server VM 21+35-LTS
     Docs: (doc function-name-here)
           (find-doc "part-of-name-here")
   Source: (source function-name-here)
@@ -119,11 +119,11 @@ OpenJDK 64-Bit Server VM 17.0.7+7
     Exit: Control+D or (exit) or (quit)
  Results: Stored in vars *1, *2, *3, an exception in *e
 
-my-project.core=> (require `[uap-clj.core :as u])
+uap-clj.core=> (require `[uap-clj.core :as u])
 nil
-my-project.core=> (def my-useragent "Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4")
-#'my-project.core/my-useragent
-my-project.core=> (pprint (u/useragent my-useragent))
+uap-clj.core=> (def my-useragent "Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4")
+#'uap-clj.core/my-useragent
+uap-clj.core=> (pprint (uap-clj.core/useragent my-useragent))
 {:ua
  "Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4",
  :browser
@@ -186,7 +186,7 @@ If you have an Heroku account, [you can easily deploy a Compojure app there](htt
   (ANY "*" []
        (route/not-found (slurp (io/resource "404.html")))))
 ```
-All you need to enable the use of the `lookup-useragent` function here is to add `[uap-clj "1.7.1"]` to the `:dependencies` vector in your Compojure app's `project.clj` (or a similar entry to `deps.edn` if you're using a more modern `tools-deps` toolchain), and `[uap-clj.core :refer [lookup-useragent]]` to the `:require` vector of your `web.clj`. Then you can do this type of thing after deployment:
+All you need to enable the use of the `lookup-useragent` function here is to add `[uap-clj "1.8.0"]` to the `:dependencies` vector in your Compojure app's `project.clj` (or a similar entry to `deps.edn` if you're using a more modern `tools-deps` toolchain), and `[uap-clj.core :refer [lookup-useragent]]` to the `:require` vector of your `web.clj`. Then you can do this type of thing after deployment:
 
 ```bash
 → curl --data "ua=AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)" http://<your_app>.herokuapp.com {:ua "AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)", :browser {:family "Other", :patch nil, :major nil, :minor nil}, :os {:family "ATV OS X", :major "", :minor "", :patch "", :patch_minor ""}, :device {:family "AppleTV", :brand "Apple", :model "AppleTV"}}
@@ -214,7 +214,7 @@ Then add these dependencies to your `pom.xml`:
 <dependency>
   <groupId>uap-clj</groupId>
   <artifactId>uap-clj</artifactId>
-  <version>1.7.1</version>
+  <version>1.8.0</version>
 </dependency>
 ```
 

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,13 @@
+(ns build
+  (:require [clojure.tools.build.api :as b]))
+
+(defn outdated
+  "Check for outdated dependencies. Wraps antq.
+   Usage: clojure -T:build outdated"
+  [opts]
+  (try
+    ((requiring-resolve 'antq.tool/outdated)
+     (merge {:check-clojure-tools true} opts))
+    (catch clojure.lang.ExceptionInfo e
+      (when-not (= "Exited" (.getMessage e))
+        (throw e)))))

--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,17 @@
+{:paths ["src" "resources"]
+
+ :deps {org.clojure/clojure {:mvn/version "1.12.4"}
+        levand/immuconf     {:mvn/version "0.1.0"}}
+
+ :aliases
+ {:dev
+  {:extra-paths ["spec" "src/resources/submodules/tests"]
+   :extra-deps  {criterium/criterium       {:mvn/version "0.4.6"}
+                 speclj/speclj             {:mvn/version "3.12.1"}
+                 clj-commons/clj-yaml      {:mvn/version "1.0.29"}}
+   :jvm-opts    ["-Xss512M"]}
+
+  :build
+  {:deps {io.github.clojure/tools.build {:mvn/version "0.10.12"}
+          com.github.liquidz/antq       {:mvn/version "2.11.1276"}}
+   :ns-default build}}}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject uap-clj "1.7.1"
+(defproject uap-clj "1.8.0"
   :description "Clojure language implementation of ua-parser"
   :url "https://github.com/russellwhitaker/uap-clj"
   :license {:name "The MIT License (MIT)"
@@ -19,7 +19,7 @@
                        [#"dev_resources|submodules|^test$|test_resources|tests|docs|\.md|LICENSE|package.json"]
                        :resource-paths ["resources"]}}
   :plugins [[com.github.liquidz/antq "RELEASE"]
-            [lein-git-deps "0.0.2-SNAPSHOT"]
+            [lein-git-deps "0.0.2"]
             [speclj "3.12.1"]]
   :git-dependencies [["https://github.com/ua-parser/uap-core.git"]]
   :main ^:skip-aot uap-clj.core

--- a/project.clj
+++ b/project.clj
@@ -18,7 +18,7 @@
              :uberjar {:uberjar-exclusions
                        [#"dev_resources|submodules|^test$|test_resources|tests|docs|\.md|LICENSE|package.json"]
                        :resource-paths ["resources"]}}
-  :plugins [[com.github.liquidz/antq "RELEASE"]
+  :plugins [[com.github.liquidz/antq "2.11.1276"]
             [lein-git-deps "0.0.2"]
             [speclj "3.12.1"]]
   :git-dependencies [["https://github.com/ua-parser/uap-core.git"]]


### PR DESCRIPTION
## Prepare for v1.8.0 release

This PR follows the work in the previous PR which updated the uap-core submodule to latest upstream master (120 commits, 84 of which touched `regexes.yaml`) and regenerated `resources/regexes.edn`, bringing the test suite from 112,663 to 113,861 passing examples.

### Changes in this PR

**deps.edn & build.clj — Begin migration from Leiningen to tools.deps/tools.build**
- Added `deps.edn` mirroring `project.clj` dependency structure (main deps, `:dev` alias, `:build` alias)
- Added `build.clj` with an `outdated` task wrapping [antq](https://github.com/liquidz/antq), invoked via `clojure -T:build outdated`

**CI workflow updates (`.github/workflows/clojure.yml`)**
- Added `DeLaGuardo/setup-clojure@13.5.2` step to install Clojure CLI (`cli: latest`) and Leiningen (`lein: 2.9.1`)
- Updated `actions/checkout` from v4 to v6.0.2
- Added `submodules: recursive` to checkout step (required for uap-core submodule)
- Added `clojure -T:build outdated` step to check for outdated dependencies
- Fixed install step to run `lein git-deps` before `lein deps`

**Dependency updates**
- Updated `lein-git-deps` from 0.0.2-SNAPSHOT to 0.0.2 release in `project.clj`

**Version bump**
- Bumped project version from 1.7.1 to 1.8.0 in `project.clj` and all README references

**README updates**
- Updated REPL session output to reflect current versions (Clojure 1.12.4, JVM 21, REPL-y 0.5.1)
- Updated test result counts to 113,861 examples
- Updated Java compatibility note to "through Java 21"
- Added `.cpcache/` to `.gitignore`

### Next steps

After merging this PR, tag v1.8.0 and release to Clojars.
