### PR TITLE
Replace immuconf with plain clojure.edn reader

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,6 @@
 {:paths ["src" "resources"]
 
- :deps {org.clojure/clojure {:mvn/version "1.12.4"}
-        levand/immuconf     {:mvn/version "0.1.0"}}
+ :deps {org.clojure/clojure {:mvn/version "1.12.4"}}
 
  :aliases
  {:dev

--- a/src/uap_clj/conf.clj
+++ b/src/uap_clj/conf.clj
@@ -2,7 +2,7 @@
   "Configuration setup for uap-clj.core
   "
   (:require [clojure.edn :as edn]
-            [clojure.java.io :as io :refer [resource as-file]]))
+            [clojure.java.io :as io :refer [resource]]))
 
 (defn load-edn
   "Read and parse an EDN file from a path, URL, or resource.

--- a/src/uap_clj/conf.clj
+++ b/src/uap_clj/conf.clj
@@ -1,16 +1,22 @@
 (ns uap-clj.conf
   "Configuration setup for uap-clj.core
   "
-  (:require [clojure.java.io :as io :refer [resource as-file]]))
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io :refer [resource as-file]]))
 
-(defn base-config
-  "Configuration without password secret, safe to check into SCM.
+(defn load-edn
+  "Read and parse an EDN file from a path, URL, or resource.
+  "
+  [source]
+  (with-open [r (io/reader source)]
+    (edn/read (java.io.PushbackReader. r))))
+
+(defn load-config
+  "Load base config and optionally merge a local override.
   "
   []
-  (resource "resources/config.edn"))
-
-(defn local-config
-  "Optional local override.
-  "
-  []
-  (when (.exists (as-file ".private/config.edn")) ".private/config.edn"))
+  (let [base (load-edn (resource "resources/config.edn"))
+        local-file (io/as-file ".private/config.edn")]
+    (if (.exists local-file)
+      (merge base (load-edn local-file))
+      base)))

--- a/src/uap_clj/core.clj
+++ b/src/uap_clj/core.clj
@@ -1,8 +1,6 @@
 (ns uap-clj.core
   "Core library with entrypoint main function"
-  (:require [immuconf.config :as conf]
-            [uap-clj.conf :refer [base-config
-                                  local-config]]
+  (:require [uap-clj.conf :refer [load-config]]
             [uap-clj.common :as common :refer :all]
             [uap-clj.browser :refer [browser]]
             [uap-clj.os :refer [os]]
@@ -10,15 +8,7 @@
             [clojure.java.io :as io :refer [resource]]
             [clojure.string :as s :refer [join trim]]))
 
-(defn config
-  "Load & merge configuration from a path of configuration file
-   sources.
-  "
-  []
-  (apply conf/load
-         (filter (partial not= nil)
-                 [(base-config)
-                  (local-config)])))
+(def cfg (load-config))
 
 (defn useragent
   "Look up all 3 sets of fields for:
@@ -36,7 +26,6 @@
 ;; in exchange for the tradeoff of increased memory bloat:
 (def useragent-memoized (memoize useragent))
 
-(def cfg (config))
 (def columns (:output-columns cfg))
 (def header
   (str

--- a/src/uap_clj/core.clj
+++ b/src/uap_clj/core.clj
@@ -5,7 +5,7 @@
             [uap-clj.browser :refer [browser]]
             [uap-clj.os :refer [os]]
             [uap-clj.device :refer [device]]
-            [clojure.java.io :as io :refer [resource]]
+            [clojure.java.io :as io]
             [clojure.string :as s :refer [join trim]]))
 
 (def cfg (load-config))


### PR DESCRIPTION
## Summary

Replace the unmaintained `levand/immuconf` dependency (last updated 2014) with plain `clojure.edn/read`.

### Changes

**src/uap_clj/conf.clj**
- Replace `base-config`/`local-config` path-returning functions with `load-edn` and `load-config`
- `load-config` reads base config EDN and optionally merges `.private/config.edn` override

**src/uap_clj/core.clj**
- Remove `immuconf.config` require
- Replace `config` function with direct call to `load-config`

**deps.edn**
- Remove `levand/immuconf` dependency

### Testing

All 113,861 test examples pass with 0 failures.
