### PR TITLE
Bump version to 1.8.1, add tag and release tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The canonical version of this project lives at [`russellwhitaker/uap-clj`](https
 Add this to your `deps.edn`:
 
 ```clojure
-uap-clj/uap-clj {:mvn/version "1.8.0"}
+uap-clj/uap-clj {:mvn/version "1.8.1"}
 ```
 
 [![Clojars Project](http://clojars.org/uap-clj/latest-version.svg)](http://clojars.org/uap-clj)
@@ -54,10 +54,10 @@ To generate your classes and .jar files:
 
 ```console
 $ clojure -T:build jar
-Built target/uap-clj-1.8.0.jar
+Built target/uap-clj-1.8.1.jar
 
 $ clojure -T:build uber
-Built target/uap-clj-1.8.0-standalone.jar
+Built target/uap-clj-1.8.1-standalone.jar
 ```
 
 To deploy to Clojars:
@@ -97,7 +97,7 @@ The basic utility functions of this library comprise `useragent`, `browser`, `os
 ### Commandline (CLI)
 
 ```bash
-/usr/bin/java -jar uap-clj-1.8.0-standalone.jar <input_filename> [<optional_out_filename>]
+/usr/bin/java -jar uap-clj-1.8.1-standalone.jar <input_filename> [<optional_out_filename>]
 ```
 
 This command takes as its first argument the name of a text file containing one useragent per line, and prints a TSV (tab-separated) file - defaulting to `useragent_lookup.tsv` - with this line format:
@@ -188,7 +188,7 @@ If you have an Heroku account, [you can easily deploy a Compojure app there](htt
   (ANY "*" []
        (route/not-found (slurp (io/resource "404.html")))))
 ```
-All you need to enable the use of the `lookup-useragent` function here is to add `uap-clj/uap-clj {:mvn/version "1.8.0"}` to your `deps.edn` and `[uap-clj.core :refer [lookup-useragent]]` to the `:require` vector of your `web.clj`. Then you can do this type of thing after deployment:
+All you need to enable the use of the `lookup-useragent` function here is to add `uap-clj/uap-clj {:mvn/version "1.8.1"}` to your `deps.edn` and `[uap-clj.core :refer [lookup-useragent]]` to the `:require` vector of your `web.clj`. Then you can do this type of thing after deployment:
 
 ```bash
 → curl --data "ua=AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)" http://<your_app>.herokuapp.com {:ua "AppleCoreMedia/1.0.0.12F69 (Apple TV; U; CPU OS 8_3 like Mac OS X; en_us)", :browser {:family "Other", :patch nil, :major nil, :minor nil}, :os {:family "ATV OS X", :major "", :minor "", :patch "", :patch_minor ""}, :device {:family "AppleTV", :brand "Apple", :model "AppleTV"}}
@@ -216,7 +216,7 @@ Then add these dependencies to your `pom.xml`:
 <dependency>
   <groupId>uap-clj</groupId>
   <artifactId>uap-clj</artifactId>
-  <version>1.8.0</version>
+  <version>1.8.1</version>
 </dependency>
 ```
 

--- a/build.clj
+++ b/build.clj
@@ -118,7 +118,8 @@
   [_]
   (let [tag (str "v" version)
         result (b/process {:command-args ["git" "tag" "-a" tag "-m" (str "Release " tag)]
-                           :dir "."})]
+                           :dir "."
+                           :inherit true})]
     (when-not (zero? (:exit result))
       (throw (ex-info (str "Failed to create tag " tag) result)))
     (println "Created tag" tag)))
@@ -129,6 +130,13 @@
    After running, push the tag with: git push origin v<version>
    Usage: clojure -T:build release"
   [_]
+  (let [release-tag (str "v" version)
+        check (b/process {:command-args ["git" "rev-parse" "-q" "--verify"
+                                         (str "refs/tags/" release-tag)]
+                          :dir "."})]
+    (when (zero? (:exit check))
+      (throw (ex-info (str "Tag " release-tag " already exists; aborting release before deploy.")
+                       check))))
   (deploy nil)
   (tag nil)
   (println (str "\nRelease " version " complete."

--- a/build.clj
+++ b/build.clj
@@ -3,7 +3,7 @@
   (:refer-clojure :exclude [test]))
 
 (def lib 'uap-clj/uap-clj)
-(def version "1.8.0")
+(def version "1.8.1")
 (def class-dir "target/classes")
 (def jar-file (format "target/%s-%s.jar" (name lib) version))
 (def uber-file (format "target/%s-%s-standalone.jar" (name lib) version))
@@ -110,6 +110,29 @@
                  (.start))]
     (when-not (zero? (.waitFor proc))
       (throw (ex-info "Tests failed" {:exit (.exitValue proc)})))))
+
+(defn tag
+  "Create a git tag for the current version (e.g. v1.8.1).
+   Fails if the tag already exists.
+   Usage: clojure -T:build tag"
+  [_]
+  (let [tag (str "v" version)
+        result (b/process {:command-args ["git" "tag" "-a" tag "-m" (str "Release " tag)]
+                           :dir "."})]
+    (when-not (zero? (:exit result))
+      (throw (ex-info (str "Failed to create tag " tag) result)))
+    (println "Created tag" tag)))
+
+(defn release
+  "Build, deploy to Clojars, and create a git tag.
+   Requires CLOJARS_USERNAME and CLOJARS_PASSWORD env vars.
+   After running, push the tag with: git push origin v<version>
+   Usage: clojure -T:build release"
+  [_]
+  (deploy nil)
+  (tag nil)
+  (println (str "\nRelease " version " complete."
+                "\nPush the tag with: git push origin v" version)))
 
 (defn outdated
   "Check for outdated dependencies. Wraps antq.


### PR DESCRIPTION
## Summary

Bump version to 1.8.1 and add automated release workflow tasks.

## Changes

### Version bump
- `build.clj`: version `1.8.0` → `1.8.1`
- `README.md`: all 5 version references updated (deps.edn coordinate, jar filenames, CLI example, RESTful API section, pom.xml dependency)

### New build tasks
- **`tag`**: creates an annotated git tag `v<version>` derived from the single-sourced `version` def in `build.clj`. Fails if the tag already exists.
  ```
  clojure -T:build tag
  ```
- **`release`**: runs `deploy` (jar build + Clojars push) then `tag`, keeping the Clojars artifact and git tag synchronized.
  ```
  CLOJARS_USERNAME=<user> CLOJARS_PASSWORD=<token> clojure -T:build release
  ```

### Verification
- Tests pass: 17 tests, 113,861 assertions, 0 failures
- Jar builds as `uap-clj-1.8.1.jar`
- Tag task verified (created and deleted test tag)
