### PR TITLE
Automate full release workflow: tag push + GitHub Release

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -1,5 +1,6 @@
 (ns build
-  (:require [clojure.tools.build.api :as b])
+  (:require [clojure.tools.build.api :as b]
+            [clojure.string :as str])
   (:refer-clojure :exclude [test]))
 
 (def lib 'uap-clj/uap-clj)
@@ -125,9 +126,8 @@
     (println "Created tag" tag)))
 
 (defn release
-  "Build, deploy to Clojars, and create a git tag.
-   Requires CLOJARS_USERNAME and CLOJARS_PASSWORD env vars.
-   After running, push the tag with: git push origin v<version>
+  "Build, deploy to Clojars, create a git tag, push it, and create a GitHub Release.
+   Requires CLOJARS_USERNAME and CLOJARS_PASSWORD env vars, and gh CLI.
    Usage: clojure -T:build release"
   [_]
   (let [release-tag (str "v" version)
@@ -139,8 +139,30 @@
                        check))))
   (deploy nil)
   (tag nil)
-  (println (str "\nRelease " version " complete."
-                "\nPush the tag with: git push origin v" version)))
+  (let [release-tag (str "v" version)
+        push (b/process {:command-args ["git" "push" "origin" release-tag]
+                         :dir "."
+                         :inherit true})]
+    (when-not (zero? (:exit push))
+      (throw (ex-info (str "Failed to push tag " release-tag) push))))
+  (let [release-tag (str "v" version)
+        prev-tag (-> (b/process {:command-args ["git" "describe" "--tags" "--abbrev=0"
+                                                (str release-tag "^")]
+                                 :dir "."})
+                     :out
+                     str/trim)
+        body (str "**Full Changelog**: https://github.com/russellwhitaker/uap-clj/compare/"
+                  prev-tag "..." release-tag)
+        gh (b/process {:command-args ["gh" "api" "repos/russellwhitaker/uap-clj/releases"
+                                      "-X" "POST"
+                                      "-f" (str "tag_name=" release-tag)
+                                      "-f" (str "name=" release-tag)
+                                      "-f" (str "body=" body)]
+                       :dir "."
+                       :inherit true})]
+    (when-not (zero? (:exit gh))
+      (throw (ex-info "Failed to create GitHub Release" gh))))
+  (println (str "\nRelease " version " complete.")))
 
 (defn outdated
   "Check for outdated dependencies. Wraps antq.

--- a/build.clj
+++ b/build.clj
@@ -125,15 +125,29 @@
       (throw (ex-info (str "Failed to create tag " tag) result)))
     (println "Created tag" tag)))
 
+(defn- github-repo
+  "Derive owner/repo from the origin remote URL."
+  []
+  (let [result (b/process {:command-args ["git" "remote" "get-url" "origin"]
+                           :dir "."})]
+    (when-not (zero? (:exit result))
+      (throw (ex-info "Failed to get origin remote URL" result)))
+    (let [url (str/trim (:out result))]
+      (second (re-find #"github\.com[:/](.+?)(?:\.git)?$" url)))))
+
 (defn release
   "Build, deploy to Clojars, create a git tag, push it, and create a GitHub Release.
    Requires CLOJARS_USERNAME and CLOJARS_PASSWORD env vars, and gh CLI.
    Usage: clojure -T:build release"
   [_]
-  (let [release-tag (str "v" version)]
-    ;; Pre-flight: check tag doesn't exist locally or on remote
-    (b/process {:command-args ["git" "fetch" "--tags" "origin"]
-                :dir "."})
+  (let [release-tag (str "v" version)
+        repo (github-repo)]
+    ;; Pre-flight: fetch remote tags and check tag doesn't exist
+    (let [fetch (b/process {:command-args ["git" "fetch" "--tags" "origin"]
+                            :dir "."})]
+      (when-not (zero? (:exit fetch))
+        (throw (ex-info "Failed to fetch tags from origin; aborting release before deploy."
+                         fetch))))
     (let [check (b/process {:command-args ["git" "rev-parse" "-q" "--verify"
                                            (str "refs/tags/" release-tag)]
                             :dir "."})]
@@ -155,10 +169,10 @@
                                     :dir "."})
           body (if (zero? (:exit prev-tag-proc))
                  (let [prev-tag (str/trim (:out prev-tag-proc))]
-                   (str "**Full Changelog**: https://github.com/russellwhitaker/uap-clj/compare/"
+                   (str "**Full Changelog**: https://github.com/" repo "/compare/"
                         prev-tag "..." release-tag))
                  (str "Release " release-tag))
-          gh (b/process {:command-args ["gh" "api" "repos/russellwhitaker/uap-clj/releases"
+          gh (b/process {:command-args ["gh" "api" (str "repos/" repo "/releases")
                                         "-X" "POST"
                                         "-f" (str "tag_name=" release-tag)
                                         "-f" (str "name=" release-tag)

--- a/build.clj
+++ b/build.clj
@@ -130,39 +130,44 @@
    Requires CLOJARS_USERNAME and CLOJARS_PASSWORD env vars, and gh CLI.
    Usage: clojure -T:build release"
   [_]
-  (let [release-tag (str "v" version)
-        check (b/process {:command-args ["git" "rev-parse" "-q" "--verify"
-                                         (str "refs/tags/" release-tag)]
-                          :dir "."})]
-    (when (zero? (:exit check))
-      (throw (ex-info (str "Tag " release-tag " already exists; aborting release before deploy.")
-                       check))))
-  (deploy nil)
-  (tag nil)
-  (let [release-tag (str "v" version)
-        push (b/process {:command-args ["git" "push" "origin" release-tag]
+  (let [release-tag (str "v" version)]
+    ;; Pre-flight: check tag doesn't exist locally or on remote
+    (b/process {:command-args ["git" "fetch" "--tags" "origin"]
+                :dir "."})
+    (let [check (b/process {:command-args ["git" "rev-parse" "-q" "--verify"
+                                           (str "refs/tags/" release-tag)]
+                            :dir "."})]
+      (when (zero? (:exit check))
+        (throw (ex-info (str "Tag " release-tag " already exists; aborting release before deploy.")
+                         check))))
+    ;; Deploy to Clojars and create local tag
+    (deploy nil)
+    (tag nil)
+    ;; Push tag to origin
+    (let [push (b/process {:command-args ["git" "push" "origin" release-tag]
+                           :dir "."
+                           :inherit true})]
+      (when-not (zero? (:exit push))
+        (throw (ex-info (str "Failed to push tag " release-tag) push))))
+    ;; Create GitHub Release
+    (let [prev-tag-proc (b/process {:command-args ["git" "describe" "--tags" "--abbrev=0"
+                                                   (str release-tag "^")]
+                                    :dir "."})
+          body (if (zero? (:exit prev-tag-proc))
+                 (let [prev-tag (str/trim (:out prev-tag-proc))]
+                   (str "**Full Changelog**: https://github.com/russellwhitaker/uap-clj/compare/"
+                        prev-tag "..." release-tag))
+                 (str "Release " release-tag))
+          gh (b/process {:command-args ["gh" "api" "repos/russellwhitaker/uap-clj/releases"
+                                        "-X" "POST"
+                                        "-f" (str "tag_name=" release-tag)
+                                        "-f" (str "name=" release-tag)
+                                        "-f" (str "body=" body)]
                          :dir "."
                          :inherit true})]
-    (when-not (zero? (:exit push))
-      (throw (ex-info (str "Failed to push tag " release-tag) push))))
-  (let [release-tag (str "v" version)
-        prev-tag (-> (b/process {:command-args ["git" "describe" "--tags" "--abbrev=0"
-                                                (str release-tag "^")]
-                                 :dir "."})
-                     :out
-                     str/trim)
-        body (str "**Full Changelog**: https://github.com/russellwhitaker/uap-clj/compare/"
-                  prev-tag "..." release-tag)
-        gh (b/process {:command-args ["gh" "api" "repos/russellwhitaker/uap-clj/releases"
-                                      "-X" "POST"
-                                      "-f" (str "tag_name=" release-tag)
-                                      "-f" (str "name=" release-tag)
-                                      "-f" (str "body=" body)]
-                       :dir "."
-                       :inherit true})]
-    (when-not (zero? (:exit gh))
-      (throw (ex-info "Failed to create GitHub Release" gh))))
-  (println (str "\nRelease " version " complete.")))
+      (when-not (zero? (:exit gh))
+        (throw (ex-info "Failed to create GitHub Release" gh))))
+    (println (str "\nRelease " version " complete."))))
 
 (defn outdated
   "Check for outdated dependencies. Wraps antq.


### PR DESCRIPTION
## Summary

Automate the full release workflow in `clojure -T:build release`.

## Changes

The `release` task now handles the complete flow end-to-end:

1. **Pre-flight check** — fail fast if the git tag already exists
2. **Build + deploy** — jar to Clojars
3. **Create git tag** — annotated tag `v<version>`
4. **Push tag** — `git push origin v<version>`
5. **Create GitHub Release** — via `gh` CLI, with auto-generated changelog link (detects previous tag via `git describe`)

### Requirements
- `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` env vars
- `gh` CLI authenticated
