### PR TITLE
Add cljstyle formatting: config, CI check, pre-commit hook

### DIFF
--- a/.cljstyle
+++ b/.cljstyle
@@ -1,0 +1,4 @@
+{:rules
+ {:indentation
+  {:list-indent 1
+   :indents {try+ [[:block 0]]}}}}

--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -31,7 +31,9 @@ jobs:
         key: clojure-${{ hashFiles('deps.edn') }}
         restore-keys: clojure-
     - name: Install dependencies
-      run: clojure -P && clojure -P -M:test && clojure -P -T:build
+      run: clojure -P && clojure -P -M:test && clojure -P -M:cljstyle-check && clojure -P -T:build
+    - name: Check formatting
+      run: clojure -M:cljstyle-check
     - name: Check for outdated dependencies
       run: clojure -T:build outdated
     - name: Run tests

--- a/build.clj
+++ b/build.clj
@@ -1,7 +1,9 @@
 (ns build
-  (:require [clojure.tools.build.api :as b]
-            [clojure.string :as str])
-  (:refer-clojure :exclude [test]))
+  (:refer-clojure :exclude [test])
+  (:require
+   [clojure.string :as str]
+   [clojure.tools.build.api :as b]))
+
 
 (def lib 'uap-clj/uap-clj)
 (def version "1.8.1")
@@ -10,6 +12,7 @@
 (def uber-file (format "target/%s-%s-standalone.jar" (name lib) version))
 
 (def basis (delay (b/create-basis {:project "deps.edn"})))
+
 
 (def pom-data
   [[:description "Clojure language implementation of ua-parser"]
@@ -24,11 +27,13 @@
     [:developerConnection "scm:git:ssh://git@github.com/russellwhitaker/uap-clj.git"]
     [:tag (str "v" version)]]])
 
+
 (defn clean
   "Delete the target directory.
    Usage: clojure -T:build clean"
   [_]
   (b/delete {:path "target"}))
+
 
 (defn compile-java
   "AOT compile gen-class namespaces for the Java API.
@@ -40,6 +45,7 @@
                   :ns-compile ['uap-clj.java.api.browser
                                'uap-clj.java.api.device
                                'uap-clj.java.api.os]}))
+
 
 (defn jar
   "Build the library JAR for deployment to Clojars.
@@ -66,6 +72,7 @@
           :jar-file jar-file})
   (println "Built" jar-file))
 
+
 (defn uber
   "Build a standalone uberjar.
    Usage: clojure -T:build uber"
@@ -90,6 +97,7 @@
            :main 'uap-clj.core})
   (println "Built" uber-file))
 
+
 (defn deploy
   "Deploy the library JAR to Clojars.
    Requires CLOJARS_USERNAME and CLOJARS_PASSWORD env vars.
@@ -102,6 +110,7 @@
     :pom-file (b/pom-path {:lib lib :class-dir class-dir})
     :sign-releases? false}))
 
+
 (defn test
   "Run the clojure.test suite via Cognitect test-runner.
    Usage: clojure -T:build test"
@@ -111,6 +120,7 @@
                  (.start))]
     (when-not (zero? (.waitFor proc))
       (throw (ex-info "Tests failed" {:exit (.exitValue proc)})))))
+
 
 (defn tag
   "Create a git tag for the current version (e.g. v1.8.1).
@@ -125,6 +135,7 @@
       (throw (ex-info (str "Failed to create tag " tag) result)))
     (println "Created tag" tag)))
 
+
 (defn- github-repo
   "Derive owner/repo from the origin remote URL."
   []
@@ -134,6 +145,7 @@
       (throw (ex-info "Failed to get origin remote URL" result)))
     (let [url (str/trim (:out result))]
       (second (re-find #"github\.com[:/](.+?)(?:\.git)?$" url)))))
+
 
 (defn release
   "Build, deploy to Clojars, create a git tag, push it, and create a GitHub Release.
@@ -147,13 +159,13 @@
                             :dir "."})]
       (when-not (zero? (:exit fetch))
         (throw (ex-info "Failed to fetch tags from origin; aborting release before deploy."
-                         fetch))))
+                        fetch))))
     (let [check (b/process {:command-args ["git" "rev-parse" "-q" "--verify"
                                            (str "refs/tags/" release-tag)]
                             :dir "."})]
       (when (zero? (:exit check))
         (throw (ex-info (str "Tag " release-tag " already exists; aborting release before deploy.")
-                         check))))
+                        check))))
     ;; Deploy to Clojars and create local tag
     (deploy nil)
     (tag nil)
@@ -182,6 +194,7 @@
       (when-not (zero? (:exit gh))
         (throw (ex-info "Failed to create GitHub Release" gh))))
     (println (str "\nRelease " version " complete."))))
+
 
 (defn outdated
   "Check for outdated dependencies. Wraps antq.

--- a/deps.edn
+++ b/deps.edn
@@ -23,4 +23,12 @@
           io.github.clojure/tools.build  {:mvn/version "0.10.12"}
           com.github.liquidz/antq        {:mvn/version "2.11.1276"}
           slipset/deps-deploy            {:mvn/version "0.2.2"}}
-   :ns-default build}}}
+   :ns-default build}
+
+  :cljstyle-check
+  {:extra-deps {mvxcvi/cljstyle {:mvn/version "0.17.642"}}
+   :main-opts  ["-m" "cljstyle.main" "check"]}
+
+  :cljstyle-fix
+  {:extra-deps {mvxcvi/cljstyle {:mvn/version "0.17.642"}}
+   :main-opts  ["-m" "cljstyle.main" "fix"]}}}

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run cljstyle fix on staged Clojure files
+# Install: cp hooks/pre-commit .git/hooks/pre-commit
+
+set -euo pipefail
+
+staged_clj_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.clj' '*.cljc' '*.cljs' '*.edn')
+
+if [[ -z "$staged_clj_files" ]]; then
+  exit 0
+fi
+
+echo "Running cljstyle fix on staged Clojure files..."
+echo "$staged_clj_files" | xargs clojure -M:cljstyle-fix
+
+# Re-stage any files that were reformatted
+echo "$staged_clj_files" | xargs git add
+
+echo "cljstyle fix complete."

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,19 +1,19 @@
 #!/usr/bin/env bash
 # Pre-commit hook: run cljstyle fix on staged Clojure files
-# Install: cp hooks/pre-commit .git/hooks/pre-commit
+# Install: cp hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
 
 set -euo pipefail
 
-staged_clj_files=$(git diff --cached --name-only --diff-filter=ACM -- '*.clj' '*.cljc' '*.cljs' '*.edn')
+staged=$(git diff --cached --name-only --diff-filter=ACM -z -- '*.clj' '*.cljc' '*.cljs' '*.edn')
 
-if [[ -z "$staged_clj_files" ]]; then
+if [[ -z "$staged" ]]; then
   exit 0
 fi
 
 echo "Running cljstyle fix on staged Clojure files..."
-echo "$staged_clj_files" | xargs clojure -M:cljstyle-fix
+git diff --cached --name-only --diff-filter=ACM -z -- '*.clj' '*.cljc' '*.cljs' '*.edn' | xargs -0 clojure -M:cljstyle-fix
 
 # Re-stage any files that were reformatted
-echo "$staged_clj_files" | xargs git add
+git diff --cached --name-only --diff-filter=ACM -z -- '*.clj' '*.cljc' '*.cljs' '*.edn' | xargs -0 git add
 
 echo "cljstyle fix complete."

--- a/src/uap_clj/browser.clj
+++ b/src/uap_clj/browser.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.browser
   "Useragent browser lookup"
-  (:require [uap-clj.common :refer [regexes-all first-match field]]
-            [clojure.java.io :as io :refer [resource]]
-            [clojure.string :as s :refer [join trim]]))
+  (:require
+   [clojure.java.io :as io :refer [resource]]
+   [clojure.string :as s :refer [join trim]]
+   [uap-clj.common :refer [regexes-all first-match field]]))
+
 
 (def regexes (:user_agent_parsers regexes-all))
+
 
 (defn browser
   [ua]
@@ -20,6 +23,7 @@
           {:family family :major major :minor minor :patch patch})))
     (catch java.lang.IndexOutOfBoundsException e
       {:family "Other" :major nil :minor nil :patch nil})))
+
 
 ;; For use in production settings where speed may be preferred
 ;; in exchange for the tradeoff of increased memory bloat:

--- a/src/uap_clj/common.clj
+++ b/src/uap_clj/common.clj
@@ -1,11 +1,15 @@
 (ns uap-clj.common
   "Common functions for field matching"
-  (:require [clojure.edn :as edn]
-            [clojure.java.io :as io :refer [resource]]
-            [clojure.string :as s :refer [join trim]]))
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io :refer [resource]]
+   [clojure.string :as s :refer [join trim]]))
 
-(def regexes-all (edn/read-string {:reader {'ordered/map sorted-map}}
-                                  (slurp (io/resource "regexes.edn"))))
+
+(def regexes-all
+  (edn/read-string {:reader {'ordered/map sorted-map}}
+                   (slurp (io/resource "regexes.edn"))))
+
 
 (defn match-with-context
   "Return match result with match groups & regex replacement map,
@@ -22,6 +26,7 @@
     (catch java.lang.NullPointerException e
       {:ua line :result {} :regex (merge regex {:regex nil})})))
 
+
 (defn first-match
   "The uaparser/core specification indicates that for each type
    (browser, o/s, device), the first successful match for a regex
@@ -32,10 +37,11 @@
   "
   [ua regexes]
   (or
-    (first
-      (filter #(not (nil? (:result %)))
-              (map #(match-with-context ua %) regexes)))
-    {:ua ua :result "Other"}))
+   (first
+    (filter #(not (nil? (:result %)))
+            (map #(match-with-context ua %) regexes)))
+   {:ua ua :result "Other"}))
+
 
 (defn field
   "Extract individual type field or supply an alternate substitute

--- a/src/uap_clj/conf.clj
+++ b/src/uap_clj/conf.clj
@@ -1,8 +1,10 @@
 (ns uap-clj.conf
   "Configuration setup for uap-clj.core
   "
-  (:require [clojure.edn :as edn]
-            [clojure.java.io :as io :refer [resource]]))
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io :refer [resource]]))
+
 
 (defn load-edn
   "Read and parse an EDN file from a path, URL, or resource.
@@ -10,6 +12,7 @@
   [source]
   (with-open [r (io/reader source)]
     (edn/read (java.io.PushbackReader. r))))
+
 
 (defn load-config
   "Load base config and optionally merge a local override.

--- a/src/uap_clj/core.clj
+++ b/src/uap_clj/core.clj
@@ -1,14 +1,17 @@
 (ns uap-clj.core
   "Core library with entrypoint main function"
-  (:require [uap-clj.conf :refer [load-config]]
-            [uap-clj.common :as common :refer :all]
-            [uap-clj.browser :refer [browser]]
-            [uap-clj.os :refer [os]]
-            [uap-clj.device :refer [device]]
-            [clojure.java.io :as io]
-            [clojure.string :as s :refer [join trim]]))
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as s :refer [join trim]]
+   [uap-clj.browser :refer [browser]]
+   [uap-clj.common :as common :refer :all]
+   [uap-clj.conf :refer [load-config]]
+   [uap-clj.device :refer [device]]
+   [uap-clj.os :refer [os]]))
+
 
 (def cfg (load-config))
+
 
 (defn useragent
   "Look up all 3 sets of fields for:
@@ -22,17 +25,21 @@
    :os (os ua)
    :device (device ua)})
 
+
 ;; For use in production settings where speed may be preferred
 ;; in exchange for the tradeoff of increased memory bloat:
 (def useragent-memoized (memoize useragent))
 
 (def columns (:output-columns cfg))
+
+
 (def header
   (str
-    (s/join \tab
-            (map #(s/join " " (map name (flatten %)))
-                 columns))
-    \newline))
+   (s/join \tab
+           (map #(s/join " " (map name (flatten %)))
+                columns))
+   \newline))
+
 
 (defn -main
   "Takes a filename from the commandline containing one useragent
@@ -47,9 +54,9 @@
     (let [out-file (or (first opt-args)
                        (:output-filename cfg))
           results (doall
-                    (map useragent (line-seq rdr)))]
+                   (map useragent (line-seq rdr)))]
       (with-open
-        [wtr (clojure.java.io/writer out-file :append false)]
+       [wtr (clojure.java.io/writer out-file :append false)]
         (.write wtr header)
         (doseq [ua results]
           (.write wtr

--- a/src/uap_clj/device.clj
+++ b/src/uap_clj/device.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.device
   "Useragent device lookup"
-  (:require [uap-clj.common :refer [regexes-all first-match field]]
-            [clojure.java.io :as io :refer [resource]]
-            [clojure.string :as s :refer [join trim]]))
+  (:require
+   [clojure.java.io :as io :refer [resource]]
+   [clojure.string :as s :refer [join trim]]
+   [uap-clj.common :refer [regexes-all first-match field]]))
+
 
 (def regexes (:device_parsers regexes-all))
+
 
 (defn device
   [ua]
@@ -19,6 +22,7 @@
           {:family family :brand brand :model model})))
     (catch java.lang.IndexOutOfBoundsException e
       {:family "Other" :brand nil :model nil})))
+
 
 ;; For use in production settings where speed may be preferred
 ;; in exchange for the tradeoff of increased memory bloat:

--- a/src/uap_clj/java/api/browser.clj
+++ b/src/uap_clj/java/api/browser.clj
@@ -1,13 +1,17 @@
 (ns uap-clj.java.api.browser
   "Java API wrapper for useragent browser lookup"
-  (:require [uap-clj.browser :refer [browser]]
-            [clojure.walk :refer [stringify-keys]])
-  (:import [java.util HashMap])
   (:gen-class
    :name uap_clj.java.api.Browser
-   :methods [#^{:static true} [lookup [String] java.util.HashMap]]))
+   :methods [#^{:static true} [lookup [String] java.util.HashMap]])
+  (:require
+   [clojure.walk :refer [stringify-keys]]
+   [uap-clj.browser :refer [browser]])
+  (:import
+   (java.util
+    HashMap)))
+
 
 (defn -lookup
   [useragent]
   (HashMap.
-    (stringify-keys (browser useragent))))
+   (stringify-keys (browser useragent))))

--- a/src/uap_clj/java/api/device.clj
+++ b/src/uap_clj/java/api/device.clj
@@ -1,13 +1,17 @@
 (ns uap-clj.java.api.device
   "Java API wrapper for useragent device lookup"
-  (:require [uap-clj.device :refer [device]]
-            [clojure.walk :refer [stringify-keys]])
-  (:import [java.util HashMap])
   (:gen-class
    :name uap_clj.java.api.Device
-   :methods [#^{:static true} [lookup [String] java.util.HashMap]]))
+   :methods [#^{:static true} [lookup [String] java.util.HashMap]])
+  (:require
+   [clojure.walk :refer [stringify-keys]]
+   [uap-clj.device :refer [device]])
+  (:import
+   (java.util
+    HashMap)))
+
 
 (defn -lookup
   [useragent]
   (HashMap.
-    (stringify-keys (device useragent))))
+   (stringify-keys (device useragent))))

--- a/src/uap_clj/java/api/os.clj
+++ b/src/uap_clj/java/api/os.clj
@@ -1,13 +1,17 @@
 (ns uap-clj.java.api.os
   "Java API wrapper for useragent o/s lookup"
-  (:require [uap-clj.os :refer [os]]
-            [clojure.walk :refer [stringify-keys]])
-  (:import [java.util HashMap])
   (:gen-class
    :name uap_clj.java.api.OS
-   :methods [#^{:static true} [lookup [String] java.util.HashMap]]))
+   :methods [#^{:static true} [lookup [String] java.util.HashMap]])
+  (:require
+   [clojure.walk :refer [stringify-keys]]
+   [uap-clj.os :refer [os]])
+  (:import
+   (java.util
+    HashMap)))
+
 
 (defn -lookup
   [useragent]
   (HashMap.
-    (stringify-keys (os useragent))))
+   (stringify-keys (os useragent))))

--- a/src/uap_clj/os.clj
+++ b/src/uap_clj/os.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.os
   "Useragent o/s lookup"
-  (:require [uap-clj.common :refer [regexes-all first-match field]]
-            [clojure.java.io :as io :refer [resource]]
-            [clojure.string :as s :refer [join trim]]))
+  (:require
+   [clojure.java.io :as io :refer [resource]]
+   [clojure.string :as s :refer [join trim]]
+   [uap-clj.common :refer [regexes-all first-match field]]))
+
 
 (def regexes (:os_parsers regexes-all))
+
 
 (defn os
   [ua]
@@ -30,6 +33,7 @@
        :patch nil
        :patch_minor nil})))
 
-; For use in production settings where speed may be preferred
-;  in exchange for the tradeoff of increased memory bloat:
+
+;; For use in production settings where speed may be preferred
+;;  in exchange for the tradeoff of increased memory bloat:
 (def os-memoized (memoize os))

--- a/test/uap_clj/browser_test.clj
+++ b/test/uap_clj/browser_test.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.browser-test
   "Test suite for browser lookup functionality"
-  (:require [clojure.test :refer [deftest is testing]]
-            [uap-clj.browser :refer [browser]]
-            [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [uap-clj.browser :refer [browser]]
+   [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+
 
 (def tests (load-fixture "test_ua.yaml"))
+
 
 (deftest known-browsers-test
   (doseq [fixture tests]
@@ -17,10 +20,12 @@
         (is (= (str (get expected :minor "")) (str (:minor result))))
         (is (= (str (get expected :patch "")) (str (:patch result))))))))
 
+
 (deftest nil-input-test
   (testing "graceful handling of nil input"
     (is (= {:family nil :major nil :minor nil :patch nil}
            (browser nil)))))
+
 
 (deftest unknown-browser-test
   (testing (format "An as-yet uncataloged browser '%s'" unknown-ua)

--- a/test/uap_clj/core_test.clj
+++ b/test/uap_clj/core_test.clj
@@ -3,46 +3,49 @@
    'useragent' function. Exhaustive (generative) testing
    for the os, device, and browser functions - which 'useragent'
    calls - are found in their own tests."
-  (:require [clojure.test :refer [deftest is testing]]
-            [uap-clj.test-helpers :refer [unknown-ua]]
-            [uap-clj.core :refer [useragent]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [uap-clj.core :refer [useragent]]
+   [uap-clj.test-helpers :refer [unknown-ua]]))
+
 
 (deftest nil-input-test
   (testing "graceful handling of nil input"
     (is (= {:ua nil
             :browser
-              {:family nil
-               :major nil
-               :minor nil
-               :patch nil}
+            {:family nil
+             :major nil
+             :minor nil
+             :patch nil}
             :os
-              {:family nil
-               :major nil
-               :minor nil
-               :patch nil
-               :patch_minor nil}
+            {:family nil
+             :major nil
+             :minor nil
+             :patch nil
+             :patch_minor nil}
             :device
-              {:family nil
-               :brand nil
-               :model nil}}
+            {:family nil
+             :brand nil
+             :model nil}}
            (useragent nil)))))
+
 
 (deftest unknown-useragent-test
   (testing "graceful handling returns 'Other' classification"
     (is (= {:ua "Unknown new useragent in the wild/v0.1.0"
             :browser
-              {:family "Other"
-               :major nil
-               :minor nil
-               :patch nil}
+            {:family "Other"
+             :major nil
+             :minor nil
+             :patch nil}
             :os
-              {:family "Other"
-               :major nil
-               :minor nil
-               :patch nil
-               :patch_minor nil}
+            {:family "Other"
+             :major nil
+             :minor nil
+             :patch nil
+             :patch_minor nil}
             :device
-              {:family "Other"
-               :brand nil
-               :model nil}}
+            {:family "Other"
+             :brand nil
+             :model nil}}
            (useragent unknown-ua)))))

--- a/test/uap_clj/device_test.clj
+++ b/test/uap_clj/device_test.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.device-test
   "Test suite for device lookup functionality"
-  (:require [clojure.test :refer [deftest is testing]]
-            [uap-clj.device :refer [device]]
-            [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [uap-clj.device :refer [device]]
+   [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+
 
 (def tests (load-fixture "test_device.yaml"))
+
 
 (deftest known-devices-test
   (doseq [fixture tests]
@@ -16,10 +19,12 @@
         (is (= (str (get expected :brand "")) (str (:brand result))))
         (is (= (str (get expected :model "")) (str (:model result))))))))
 
+
 (deftest nil-input-test
   (testing "graceful handling of nil input"
     (is (= {:family nil :brand nil :model nil}
            (device nil)))))
+
 
 (deftest unknown-device-test
   (testing (format "An as-yet uncataloged device '%s'" unknown-ua)

--- a/test/uap_clj/java/api/browser_test.clj
+++ b/test/uap_clj/java/api/browser_test.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.java.api.browser-test
   "Test suite for Java API to browser lookup functionality"
-  (:require [clojure.test :refer [deftest is testing]]
-            [uap-clj.java.api.browser :refer [-lookup]]
-            [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [uap-clj.java.api.browser :refer [-lookup]]
+   [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+
 
 (def tests (load-fixture "test_ua.yaml"))
+
 
 (deftest known-browsers-test
   (doseq [fixture tests]
@@ -16,6 +19,7 @@
         (is (= (str (get expected :major "")) (str (.get result "major"))))
         (is (= (str (get expected :minor "")) (str (.get result "minor"))))
         (is (= (str (get expected :patch "")) (str (.get result "patch"))))))))
+
 
 (deftest unknown-browser-test
   (testing (format "An as-yet uncataloged browser '%s'" unknown-ua)

--- a/test/uap_clj/java/api/device_test.clj
+++ b/test/uap_clj/java/api/device_test.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.java.api.device-test
   "Test suite for Java API to device lookup functionality"
-  (:require [clojure.test :refer [deftest is testing]]
-            [uap-clj.java.api.device :refer [-lookup]]
-            [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [uap-clj.java.api.device :refer [-lookup]]
+   [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+
 
 (def tests (load-fixture "test_device.yaml"))
+
 
 (deftest known-devices-test
   (doseq [fixture tests]
@@ -15,6 +18,7 @@
         (is (= (str (get expected :family "")) (str (.get result "family"))))
         (is (= (str (get expected :brand "")) (str (.get result "brand"))))
         (is (= (str (get expected :model "")) (str (.get result "model"))))))))
+
 
 (deftest unknown-device-test
   (testing (format "An as-yet uncataloged device '%s'" unknown-ua)

--- a/test/uap_clj/java/api/os_test.clj
+++ b/test/uap_clj/java/api/os_test.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.java.api.os-test
   "Test suite for Java API to o/s lookup functionality"
-  (:require [clojure.test :refer [deftest is testing]]
-            [uap-clj.java.api.os :refer [-lookup]]
-            [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [uap-clj.java.api.os :refer [-lookup]]
+   [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+
 
 (def tests (load-fixture "test_os.yaml"))
+
 
 (deftest known-os-test
   (doseq [fixture tests]
@@ -17,6 +20,7 @@
         (is (= (str (get expected :minor "")) (str (.get result "minor"))))
         (is (= (str (get expected :patch "")) (str (.get result "patch"))))
         (is (= (str (get expected :patch_minor "")) (str (.get result "patch_minor"))))))))
+
 
 (deftest unknown-os-test
   (testing (format "An as-yet uncataloged o/s '%s'" unknown-ua)

--- a/test/uap_clj/os_test.clj
+++ b/test/uap_clj/os_test.clj
@@ -1,10 +1,13 @@
 (ns uap-clj.os-test
   "Test suite for o/s lookup functionality"
-  (:require [clojure.test :refer [deftest is testing]]
-            [uap-clj.os :refer [os]]
-            [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [uap-clj.os :refer [os]]
+   [uap-clj.test-helpers :refer [unknown-ua load-fixture]]))
+
 
 (def tests (load-fixture "test_os.yaml"))
+
 
 (deftest known-os-test
   (doseq [fixture tests]
@@ -18,10 +21,12 @@
         (is (= (str (get expected :patch "")) (str (:patch result))))
         (is (= (str (get expected :patch_minor "")) (str (:patch_minor result))))))))
 
+
 (deftest nil-input-test
   (testing "graceful handling of nil input"
     (is (= {:family nil :major nil :minor nil :patch nil :patch_minor nil}
            (os nil)))))
+
 
 (deftest unknown-os-test
   (testing (format "An as-yet uncataloged o/s '%s'" unknown-ua)

--- a/test/uap_clj/test_helpers.clj
+++ b/test/uap_clj/test_helpers.clj
@@ -1,14 +1,20 @@
 (ns uap-clj.test-helpers
-  (:require [clojure.java.io :as io]
-            [clj-yaml.core :refer [parse-string]])
-  (:import [org.yaml.snakeyaml LoaderOptions]))
+  (:require
+   [clj-yaml.core :refer [parse-string]]
+   [clojure.java.io :as io])
+  (:import
+   (org.yaml.snakeyaml
+    LoaderOptions)))
+
 
 (def ^:const unknown-ua "Unknown new useragent in the wild/v0.1.0")
+
 
 (defn default-codepoint-limit
   []
   (let [options (LoaderOptions.)]
     (.getCodePointLimit options)))
+
 
 (defn snakeyaml-loader-options
   ^LoaderOptions [n]
@@ -16,12 +22,13 @@
     (.setCodePointLimit options n)
     options))
 
+
 (defn load-fixture
   [f]
   (let [raw-file (slurp (io/resource f))
         file-size (count raw-file)]
     (if (>= file-size (default-codepoint-limit))
       (:test_cases
-        (with-redefs [clj-yaml.core/default-loader-options #(snakeyaml-loader-options file-size)]
-          (parse-string raw-file)))
+       (with-redefs [clj-yaml.core/default-loader-options #(snakeyaml-loader-options file-size)]
+         (parse-string raw-file)))
       (:test_cases (parse-string raw-file)))))


### PR DESCRIPTION
## Summary

Add cljstyle code formatting infrastructure: configuration, deps.edn aliases, CI enforcement, and a git pre-commit hook.

## Changes

### Formatting config
- `.cljstyle` with project rules: `list-indent 1`, `try+` block indentation

### deps.edn aliases
- `:cljstyle-check` — check formatting (`clojure -M:cljstyle-check`)
- `:cljstyle-fix` — auto-fix formatting (`clojure -M:cljstyle-fix`)
- Uses `mvxcvi/cljstyle 0.17.642`

### CI
- `.github/workflows/clojure.yml`: added `Check formatting` step before tests, fails build on style violations

### Pre-commit hook
- `hooks/pre-commit`: runs `cljstyle-fix` on staged `.clj`/`.cljc`/`.cljs`/`.edn` files and re-stages them
- Uses `git diff -z` + `xargs -0` for whitespace-safe filename handling
- Install after clone: `cp hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`

### Formatting applied
- All source and test files reformatted to pass cljstyle check
- Tests pass: 17 tests, 113,861 assertions, 0 failures
