### PR TITLE
Add CI/CD automation and GraalVM native-image build

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -1,0 +1,68 @@
+name: Native Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: uap-clj-linux-amd64
+          - os: macos-latest
+            artifact: uap-clj-macos-amd64
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        submodules: recursive
+
+    - uses: graalvm/setup-graalvm@v1
+      with:
+        java-version: '21'
+        distribution: 'graalce'
+
+    - name: Install Clojure Tools
+      uses: DeLaGuardo/setup-clojure@13.5.2
+      with:
+        cli: latest
+
+    - name: Cache Clojure dependencies
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.gitlibs
+          ~/.clojure/.cpcache
+        key: native-${{ matrix.os }}-${{ hashFiles('deps.edn') }}
+        restore-keys: native-${{ matrix.os }}-
+
+    - name: Build native image
+      run: clojure -T:build native-image
+
+    - name: Smoke test
+      run: |
+        echo "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36" > /tmp/test-ua.txt
+        ./target/uap-clj /tmp/test-ua.txt /tmp/test-output.tsv
+        cat /tmp/test-output.tsv
+        [[ -s /tmp/test-output.tsv ]]
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ matrix.artifact }}
+        path: target/uap-clj
+
+    - name: Upload to release
+      if: startsWith(github.ref, 'refs/tags/')
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        cp target/uap-clj target/${{ matrix.artifact }}
+        gh release upload ${{ github.ref_name }} target/${{ matrix.artifact }}

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -19,7 +19,7 @@ jobs:
             artifact: uap-clj-linux-amd64
           - os: macos-13
             artifact: uap-clj-macos-amd64
-          - os: macos-latest
+          - os: macos-14
             artifact: uap-clj-macos-arm64
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -33,6 +33,7 @@ jobs:
       with:
         java-version: '21'
         distribution: 'graalce'
+        native-image-job-reports: 'true'
 
     - name: Install Clojure Tools
       uses: DeLaGuardo/setup-clojure@13.5.2

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -6,8 +6,12 @@ on:
       - published
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     strategy:
       matrix:
         include:

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -1,9 +1,9 @@
 name: Native Image
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types:
+      - published
   workflow_dispatch:
 
 jobs:
@@ -13,8 +13,10 @@ jobs:
         include:
           - os: ubuntu-latest
             artifact: uap-clj-linux-amd64
-          - os: macos-latest
+          - os: macos-13
             artifact: uap-clj-macos-amd64
+          - os: macos-latest
+            artifact: uap-clj-macos-arm64
 
     runs-on: ${{ matrix.os }}
 
@@ -60,9 +62,9 @@ jobs:
         path: target/uap-clj
 
     - name: Upload to release
-      if: startsWith(github.ref, 'refs/tags/')
+      if: github.event_name == 'release'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         cp target/uap-clj target/${{ matrix.artifact }}
-        gh release upload ${{ github.ref_name }} target/${{ matrix.artifact }}
+        gh release upload ${{ github.event.release.tag_name }} target/${{ matrix.artifact }} --clobber

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'v*'
+  release:
+    types:
+      - published
 
 jobs:
   sync:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6.0.2
@@ -21,23 +23,22 @@ jobs:
         git remote add upstream https://x-access-token:${UPSTREAM_TOKEN}@github.com/ua-parser/uap-clj.git
         git push upstream master --tags
 
-    - name: Mirror GitHub Release
-      if: startsWith(github.ref, 'refs/tags/v')
+  mirror-release:
+    if: github.event_name == 'release'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Mirror GitHub Release to upstream
       env:
         GH_TOKEN: ${{ secrets.UPSTREAM_PUSH_TOKEN }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}
+        RELEASE_NAME: ${{ github.event.release.name }}
+        RELEASE_BODY: ${{ github.event.release.body }}
       run: |
-        TAG="${GITHUB_REF#refs/tags/}"
-        # Fetch release from origin repo
-        RELEASE=$(gh api repos/russellwhitaker/uap-clj/releases/tags/"$TAG" 2>/dev/null) || {
-          echo "No release found for tag $TAG on origin — skipping"
-          exit 0
-        }
-        NAME=$(echo "$RELEASE" | jq -r '.name')
-        BODY=$(echo "$RELEASE" | jq -r '.body')
-        # Create matching release on upstream
-        gh api repos/ua-parser/uap-clj/releases \
-          -X POST \
-          -f tag_name="$TAG" \
-          -f name="$NAME" \
-          -f body="$BODY" \
-          --jq '.html_url'
+        jq -n \
+          --arg tag "$RELEASE_TAG" \
+          --arg name "$RELEASE_NAME" \
+          --arg body "$RELEASE_BODY" \
+          '{tag_name: $tag, name: $name, body: $body}' \
+        | gh api repos/ua-parser/uap-clj/releases \
+            --input - \
+            --jq '.html_url'

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -1,0 +1,20 @@
+name: Sync upstream mirror
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        fetch-depth: 0
+    - name: Push to upstream mirror
+      env:
+        UPSTREAM_TOKEN: ${{ secrets.UPSTREAM_PUSH_TOKEN }}
+      run: |
+        git remote add upstream https://x-access-token:${UPSTREAM_TOKEN}@github.com/ua-parser/uap-clj.git
+        git push upstream master --tags

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -27,6 +27,15 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        fetch-depth: 0
+    - name: Push tag to upstream
+      env:
+        UPSTREAM_TOKEN: ${{ secrets.UPSTREAM_PUSH_TOKEN }}
+      run: |
+        git remote add upstream https://x-access-token:${UPSTREAM_TOKEN}@github.com/ua-parser/uap-clj.git
+        git push upstream "${{ github.event.release.tag_name }}"
     - name: Mirror GitHub Release to upstream
       env:
         GH_TOKEN: ${{ secrets.UPSTREAM_PUSH_TOKEN }}
@@ -34,6 +43,11 @@ jobs:
         RELEASE_NAME: ${{ github.event.release.name }}
         RELEASE_BODY: ${{ github.event.release.body }}
       run: |
+        # Check if release already exists upstream
+        if gh api repos/ua-parser/uap-clj/releases/tags/"$RELEASE_TAG" --silent 2>/dev/null; then
+          echo "Release $RELEASE_TAG already exists upstream — skipping"
+          exit 0
+        fi
         jq -n \
           --arg tag "$RELEASE_TAG" \
           --arg name "$RELEASE_NAME" \

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+    tags:
+      - 'v*'
 
 jobs:
   sync:
@@ -18,3 +20,24 @@ jobs:
       run: |
         git remote add upstream https://x-access-token:${UPSTREAM_TOKEN}@github.com/ua-parser/uap-clj.git
         git push upstream master --tags
+
+    - name: Mirror GitHub Release
+      if: startsWith(github.ref, 'refs/tags/v')
+      env:
+        GH_TOKEN: ${{ secrets.UPSTREAM_PUSH_TOKEN }}
+      run: |
+        TAG="${GITHUB_REF#refs/tags/}"
+        # Fetch release from origin repo
+        RELEASE=$(gh api repos/russellwhitaker/uap-clj/releases/tags/"$TAG" 2>/dev/null) || {
+          echo "No release found for tag $TAG on origin — skipping"
+          exit 0
+        }
+        NAME=$(echo "$RELEASE" | jq -r '.name')
+        BODY=$(echo "$RELEASE" | jq -r '.body')
+        # Create matching release on upstream
+        gh api repos/ua-parser/uap-clj/releases \
+          -X POST \
+          -f tag_name="$TAG" \
+          -f name="$NAME" \
+          -f body="$BODY" \
+          --jq '.html_url'

--- a/.github/workflows/sync-upstream.yml
+++ b/.github/workflows/sync-upstream.yml
@@ -40,5 +40,6 @@ jobs:
           --arg body "$RELEASE_BODY" \
           '{tag_name: $tag, name: $name, body: $body}' \
         | gh api repos/ua-parser/uap-clj/releases \
+            -X POST \
             --input - \
             --jq '.html_url'

--- a/.github/workflows/update-uap-core.yml
+++ b/.github/workflows/update-uap-core.yml
@@ -50,10 +50,14 @@ jobs:
 
     - name: Install jet
       if: steps.check.outputs.updated == 'true'
+      env:
+        JET_VERSION: "0.7.27"
       run: |
-        curl -sLO https://github.com/borkdude/jet/releases/latest/download/jet-linux-amd64.tar.gz
+        curl -sLO "https://github.com/borkdude/jet/releases/download/v${JET_VERSION}/jet-linux-amd64.tar.gz"
+        echo "Installed jet v${JET_VERSION}"
         tar xzf jet-linux-amd64.tar.gz
         sudo mv jet /usr/local/bin/
+        jet --version
 
     - name: Regenerate regexes.edn
       if: steps.check.outputs.updated == 'true'
@@ -62,9 +66,7 @@ jobs:
 
     - name: Run tests
       if: steps.check.outputs.updated == 'true'
-      run: |
-        clojure -P && clojure -P -M:test
-        clojure -M:test
+      run: clojure -M:test
 
     - name: Create pull request
       if: steps.check.outputs.updated == 'true'

--- a/.github/workflows/update-uap-core.yml
+++ b/.github/workflows/update-uap-core.yml
@@ -53,8 +53,7 @@ jobs:
       env:
         JET_VERSION: "0.7.27"
       run: |
-        curl -sLO "https://github.com/borkdude/jet/releases/download/v${JET_VERSION}/jet-linux-amd64.tar.gz"
-        echo "Installed jet v${JET_VERSION}"
+        curl -fSLO "https://github.com/borkdude/jet/releases/download/v${JET_VERSION}/jet-linux-amd64.tar.gz"
         tar xzf jet-linux-amd64.tar.gz
         sudo mv jet /usr/local/bin/
         jet --version

--- a/.github/workflows/update-uap-core.yml
+++ b/.github/workflows/update-uap-core.yml
@@ -1,0 +1,88 @@
+name: Update uap-core submodule
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Weekly on Monday at 9am UTC
+  workflow_dispatch:       # Allow manual trigger
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6.0.2
+      with:
+        submodules: recursive
+        fetch-depth: 0
+
+    - name: Check for submodule updates
+      id: check
+      run: |
+        cd src/resources/submodules
+        git fetch origin master
+        LOCAL=$(git rev-parse HEAD)
+        REMOTE=$(git rev-parse origin/master)
+        echo "local=$LOCAL" >> "$GITHUB_OUTPUT"
+        echo "remote=$REMOTE" >> "$GITHUB_OUTPUT"
+        if [[ "$LOCAL" != "$REMOTE" ]]; then
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+          COMMIT_COUNT=$(git rev-list --count HEAD..origin/master)
+          echo "commit_count=$COMMIT_COUNT" >> "$GITHUB_OUTPUT"
+        else
+          echo "updated=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Update submodule
+      if: steps.check.outputs.updated == 'true'
+      run: |
+        cd src/resources/submodules
+        git checkout origin/master
+
+    - name: Install Clojure Tools
+      if: steps.check.outputs.updated == 'true'
+      uses: DeLaGuardo/setup-clojure@13.5.2
+      with:
+        cli: latest
+
+    - name: Install jet
+      if: steps.check.outputs.updated == 'true'
+      run: |
+        curl -sLO https://github.com/borkdude/jet/releases/latest/download/jet-linux-amd64.tar.gz
+        tar xzf jet-linux-amd64.tar.gz
+        sudo mv jet /usr/local/bin/
+
+    - name: Regenerate regexes.edn
+      if: steps.check.outputs.updated == 'true'
+      run: |
+        cat src/resources/submodules/regexes.yaml | jet -i yaml -o edn -k > resources/regexes.edn
+
+    - name: Run tests
+      if: steps.check.outputs.updated == 'true'
+      run: |
+        clojure -P && clojure -P -M:test
+        clojure -M:test
+
+    - name: Create pull request
+      if: steps.check.outputs.updated == 'true'
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        branch: auto/update-uap-core
+        commit-message: |
+          Update uap-core submodule (${{ steps.check.outputs.commit_count }} commits)
+
+          Regenerate regexes.edn from latest upstream regexes.yaml.
+        title: "Update uap-core submodule (${{ steps.check.outputs.commit_count }} new commits)"
+        body: |
+          Automated update of the uap-core submodule to latest upstream.
+
+          - **Commits**: ${{ steps.check.outputs.commit_count }} new commits
+          - **Previous**: `${{ steps.check.outputs.local }}`
+          - **Updated to**: `${{ steps.check.outputs.remote }}`
+          - **regexes.edn**: regenerated from updated regexes.yaml
+          - **Tests**: passed
+        labels: dependencies

--- a/.github/workflows/update-uap-core.yml
+++ b/.github/workflows/update-uap-core.yml
@@ -52,9 +52,11 @@ jobs:
       if: steps.check.outputs.updated == 'true'
       env:
         JET_VERSION: "0.7.27"
+        JET_SHA256: "411e65cbe6ea94ea6994e22723cbc73843c715e29828cb3fb8ca6c5af639a68d"
       run: |
-        curl -fSLO "https://github.com/borkdude/jet/releases/download/v${JET_VERSION}/jet-linux-amd64.tar.gz"
-        tar xzf jet-linux-amd64.tar.gz
+        curl -fSLO "https://github.com/borkdude/jet/releases/download/v${JET_VERSION}/jet-${JET_VERSION}-linux-amd64.tar.gz"
+        echo "${JET_SHA256}  jet-${JET_VERSION}-linux-amd64.tar.gz" | sha256sum -c -
+        tar xzf "jet-${JET_VERSION}-linux-amd64.tar.gz"
         sudo mv jet /usr/local/bin/
         jet --version
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # uap-clj
 
-[![CircleCI](https://circleci.com/gh/russellwhitaker/uap-clj.svg?style=svg)](https://circleci.com/gh/russellwhitaker/uap-clj)
+[![CI](https://github.com/russellwhitaker/uap-clj/actions/workflows/clojure.yml/badge.svg)](https://github.com/russellwhitaker/uap-clj/actions/workflows/clojure.yml)
 
 A [`ua-parser/uap-core`](https://github.com/ua-parser/uap-core) based Clojure library for extracting browser, operating system, and device information from a raw useragent string.
 
@@ -99,6 +99,15 @@ The basic utility functions of this library comprise `useragent`, `browser`, `os
 ```bash
 /usr/bin/java -jar uap-clj-1.8.1-standalone.jar <input_filename> [<optional_out_filename>]
 ```
+
+A native binary (no JVM required) is also available via [GraalVM native-image](https://www.graalvm.org/latest/reference-manual/native-image/). Pre-built binaries for Linux and macOS are attached to each [GitHub Release](https://github.com/russellwhitaker/uap-clj/releases). To build locally:
+
+```console
+$ clojure -T:build native-image
+$ ./target/uap-clj <input_filename> [<optional_out_filename>]
+```
+
+This requires GraalVM CE 21+ with the `native-image` component installed.
 
 This command takes as its first argument the name of a text file containing one useragent per line, and prints a TSV (tab-separated) file - defaulting to `useragent_lookup.tsv` - with this line format:
 
@@ -289,9 +298,17 @@ Device model: A288t_TD
 [INFO] ------------------------------------------------------------------------
 ```
 
+## CI/CD
+
+This project uses [GitHub Actions](https://github.com/russellwhitaker/uap-clj/actions) for CI/CD:
+
+- **CI** (`clojure.yml`): runs tests, checks formatting (cljstyle), and checks for outdated dependencies on every push and PR.
+- **Upstream sync** (`sync-upstream.yml`): mirrors pushes to `master` (including tags) to the [`ua-parser/uap-clj`](https://github.com/ua-parser/uap-clj) upstream fork.
+- **uap-core update** (`update-uap-core.yml`): weekly scheduled check for new commits in the `ua-parser/uap-core` submodule. When updates are found, it regenerates `regexes.edn`, runs the test suite, and opens a PR automatically.
+- **Native image** (`native-image.yml`): builds GraalVM native binaries for Linux and macOS on each tagged release and uploads them as release assets.
+
 ## Future / Enhancements
 
-* add option to source `regexes.yaml` from an S3 bucket
 * add `clojure.spec`
 
 __Maintained by Russell Whitaker__

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Device model: A288t_TD
 This project uses [GitHub Actions](https://github.com/russellwhitaker/uap-clj/actions) for CI/CD:
 
 - **CI** (`clojure.yml`): runs tests, checks formatting (cljstyle), and checks for outdated dependencies on every push and PR.
-- **Upstream sync** (`sync-upstream.yml`): mirrors pushes to `master` (including tags) to the [`ua-parser/uap-clj`](https://github.com/ua-parser/uap-clj) upstream fork.
+- **Upstream sync** (`sync-upstream.yml`): mirrors pushes to `master` and tags to the [`ua-parser/uap-clj`](https://github.com/ua-parser/uap-clj) upstream fork. On release, also mirrors the GitHub Release.
 - **uap-core update** (`update-uap-core.yml`): weekly scheduled check for new commits in the `ua-parser/uap-core` submodule. When updates are found, it regenerates `regexes.edn`, runs the test suite, and opens a PR automatically.
 - **Native image** (`native-image.yml`): builds GraalVM native binaries for Linux and macOS on each tagged release and uploads them as release assets.
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ This project uses [GitHub Actions](https://github.com/russellwhitaker/uap-clj/ac
 - **CI** (`clojure.yml`): runs tests, checks formatting (cljstyle), and checks for outdated dependencies on every push and PR.
 - **Upstream sync** (`sync-upstream.yml`): mirrors pushes to `master` and tags to the [`ua-parser/uap-clj`](https://github.com/ua-parser/uap-clj) upstream fork. On release, also mirrors the GitHub Release.
 - **uap-core update** (`update-uap-core.yml`): weekly scheduled check for new commits in the `ua-parser/uap-core` submodule. When updates are found, it regenerates `regexes.edn`, runs the test suite, and opens a PR automatically.
-- **Native image** (`native-image.yml`): builds GraalVM native binaries for Linux and macOS on each tagged release and uploads them as release assets.
+- **Native image** (`native-image.yml`): builds GraalVM native binaries for Linux (amd64) and macOS (amd64, arm64) on each tagged release and uploads them as release assets.
 
 ## Future / Enhancements
 

--- a/build.clj
+++ b/build.clj
@@ -115,7 +115,6 @@
                                 "-H:+ReportExceptionStackTraces"
                                 "--initialize-at-build-time"
                                 "-H:Log=registerResource:"
-                                "-H:EnableURLProtocols=http,https"
                                 "--enable-url-protocols=http,https"]
                  :dir "."
                  :inherit true})]

--- a/build.clj
+++ b/build.clj
@@ -98,6 +98,32 @@
   (println "Built" uber-file))
 
 
+(def native-image-name (format "target/%s" (name lib)))
+
+
+(defn native-image
+  "Build a native binary using GraalVM native-image.
+   Requires GraalVM with native-image installed.
+   Usage: clojure -T:build native-image"
+  [_]
+  (uber nil)
+  (let [result (b/process
+                {:command-args ["native-image"
+                                "-jar" uber-file
+                                "-o" native-image-name
+                                "--no-fallback"
+                                "-H:+ReportExceptionStackTraces"
+                                "--initialize-at-build-time"
+                                "-H:Log=registerResource:"
+                                "-H:EnableURLProtocols=http,https"
+                                "--enable-url-protocols=http,https"]
+                 :dir "."
+                 :inherit true})]
+    (when-not (zero? (:exit result))
+      (throw (ex-info "native-image build failed" result))))
+  (println "Built" native-image-name))
+
+
 (defn deploy
   "Deploy the library JAR to Clojars.
    Requires CLOJARS_USERNAME and CLOJARS_PASSWORD env vars.

--- a/build.clj
+++ b/build.clj
@@ -115,6 +115,7 @@
                                 "-H:+ReportExceptionStackTraces"
                                 "--initialize-at-build-time"
                                 "-H:Log=registerResource:"
+                                "-H:IncludeResources=regexes.edn"
                                 "--enable-url-protocols=http,https"]
                  :dir "."
                  :inherit true})]


### PR DESCRIPTION
## Summary

Adds three new GitHub Actions workflows, a native-image build task, and README updates.

### New workflows

1. **`sync-upstream.yml`** — Mirrors pushes to `master` (including tags) to the [`ua-parser/uap-clj`](https://github.com/ua-parser/uap-clj) upstream fork. On release, pushes the tag and mirrors the GitHub Release (idempotent — skips if already exists). Requires a `UPSTREAM_PUSH_TOKEN` repository secret (classic PAT with `repo` scope).

2. **`update-uap-core.yml`** — Weekly scheduled check (Monday 9am UTC, also manual dispatch) for new commits in the `ua-parser/uap-core` submodule. When updates are found, it:
   - Updates the submodule pointer
   - Installs pinned `jet` v0.7.27 (with SHA256 verification) and regenerates `regexes.edn`
   - Runs the full test suite
   - Opens a PR automatically via `peter-evans/create-pull-request`

3. **`native-image.yml`** — Builds GraalVM native binaries on each published release (tag matching `v*`) or manual dispatch. Matrix:
   - `ubuntu-latest` → `uap-clj-linux-amd64`
   - `macos-13` → `uap-clj-macos-amd64`
   - `macos-14` → `uap-clj-macos-arm64`

   Runs a smoke test on each binary and uploads them as release assets (with `--clobber` for idempotent re-runs). Sets explicit `contents: write` permission.

### Build task

- Added `native-image` task to `build.clj`: builds an uberjar then compiles it to a native binary via GraalVM `native-image` with `--no-fallback`, `--initialize-at-build-time`, and `-H:IncludeResources=regexes.edn`.

### README updates

- Replaced CircleCI badge with GitHub Actions CI badge
- Documented native binary build and pre-built release downloads
- Added CI/CD section describing all workflows (with architecture details)
- Updated Future/Enhancements list

### Review feedback addressed

- Switched native-image and release-mirror triggers from tag push to `release` (published) to avoid race conditions with the release task
- Made release mirroring idempotent (checks for existing upstream release)
- Pinned macOS runners (`macos-13` for amd64, `macos-14` for arm64) instead of using `macos-latest`
- Added `contents: write` permission and `v*` tag guard to native-image workflow
- Added `-X POST` to `gh api` release mirror call
- Used `jq` for safe JSON payload construction (handles special chars in release body)
- Pinned jet v0.7.27 with SHA256 checksum verification
- Added `-H:IncludeResources=regexes.edn` for native-image resource embedding
- Removed duplicate native-image CLI flag
- Enabled `native-image-job-reports` in GraalVM setup
