### PR TITLE
Add benchmark suite, clojure.spec, and dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,32 @@ Ran 17 tests containing 113861 assertions.
 ```
 The test suite runs against all the browser, o/s, and device YAML fixtures in [`ua-parser/uap-core/tests`](https://github.com/ua-parser/uap-core/blob/master/tests), for both the native Clojure core library and the Java API. The `clojars` artifact is compiled with these fixtures linked as a git submodule dependency.
 
+### Benchmarks
+
+Run the [criterium](https://github.com/hugoduncan/criterium)-based benchmark suite:
+
+```console
+$ clojure -M:bench
+```
+
+This benchmarks `browser`, `os`, `device`, and `useragent` lookups individually and in batch.
+
+### Specs
+
+`clojure.spec` definitions for all parsed output maps are available in `uap-clj.spec`. To use them:
+
+```clojure
+(require '[clojure.spec.alpha :as s]
+         '[uap-clj.spec]
+         '[uap-clj.core :refer [useragent]])
+
+(s/valid? :uap-clj.spec/useragent (useragent "Mozilla/5.0 ..."))
+;; => true
+
+(s/explain :uap-clj.spec/browser {:family "Chrome" :major "120" :minor "0" :patch "0"})
+;; => Success!
+```
+
 ## Use / Production
 
 The basic utility functions of this library comprise `useragent`, `browser`, `os`, and `device`; memoized versions of the same functions are provided as conveniences for production environments where a requirement for low latency response from large numbers of rapidly repeated requests is worth the memory penalty incurred by the need to maintain a growing cache of input/output value mappings. Accordingly, these functions are named `useragent-memoized`, `browser-memoized`, `os-memoized`, and `device-memoized`.
@@ -303,7 +329,7 @@ This project uses [GitHub Actions](https://github.com/russellwhitaker/uap-clj/ac
 
 ## Future / Enhancements
 
-* add `clojure.spec`
+_No outstanding items._
 
 __Maintained by Russell Whitaker__
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # uap-clj
 
 [![CI](https://github.com/russellwhitaker/uap-clj/actions/workflows/clojure.yml/badge.svg)](https://github.com/russellwhitaker/uap-clj/actions/workflows/clojure.yml)
+[![Clojars Project](http://clojars.org/uap-clj/latest-version.svg)](http://clojars.org/uap-clj)
 
 A [`ua-parser/uap-core`](https://github.com/ua-parser/uap-core) based Clojure library for extracting browser, operating system, and device information from a raw useragent string.
 
@@ -17,8 +18,6 @@ Add this to your `deps.edn`:
 ```clojure
 uap-clj/uap-clj {:mvn/version "1.8.1"}
 ```
-
-[![Clojars Project](http://clojars.org/uap-clj/latest-version.svg)](http://clojars.org/uap-clj)
 
 `uap-clj` depends on the file `regexes.yaml` actively maintained in the public [`ua-parser/uap-core`](https://github.com/ua-parser/uap-core) repository, as well as on the test fixtures `test_ua.yaml`, `test_os.yaml`, and `test_device.yaml` contained therein. After cloning this code repository, initialize the git submodules and fetch dependencies:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # uap-clj
 
 [![CI](https://github.com/russellwhitaker/uap-clj/actions/workflows/clojure.yml/badge.svg)](https://github.com/russellwhitaker/uap-clj/actions/workflows/clojure.yml)
-[![Clojars Project](http://clojars.org/uap-clj/latest-version.svg)](http://clojars.org/uap-clj)
+[![Clojars Project](https://clojars.org/uap-clj/latest-version.svg)](https://clojars.org/uap-clj)
 
 A [`ua-parser/uap-core`](https://github.com/ua-parser/uap-core) based Clojure library for extracting browser, operating system, and device information from a raw useragent string.
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,7 +5,7 @@
  :aliases
  {:dev
   {:extra-paths ["test" "src/resources/submodules/tests"]
-   :extra-deps  {criterium/criterium       {:mvn/version "0.4.6"}
+   :extra-deps  {criterium/criterium       {:mvn/version "0.5.153-ALPHA"}
                  clj-commons/clj-yaml      {:mvn/version "1.0.29"}}
    :jvm-opts    ["-Xss512M"]}
 
@@ -28,7 +28,7 @@
 
   :bench
   {:extra-paths ["dev"]
-   :extra-deps  {criterium/criterium {:mvn/version "0.4.6"}}
+   :extra-deps  {criterium/criterium {:mvn/version "0.5.153-ALPHA"}}
    :jvm-opts    ["-Xss512M"]
    :main-opts   ["-m" "bench"]}
 

--- a/deps.edn
+++ b/deps.edn
@@ -26,6 +26,12 @@
           clj-commons/clj-yaml           {:mvn/version "1.0.29"}}
    :ns-default build}
 
+  :bench
+  {:extra-paths ["dev"]
+   :extra-deps  {criterium/criterium {:mvn/version "0.4.6"}}
+   :jvm-opts    ["-Xss512M"]
+   :main-opts   ["-m" "bench"]}
+
   :cljstyle-check
   {:extra-deps {mvxcvi/cljstyle {:mvn/version "0.17.642"}}
    :main-opts  ["-m" "cljstyle.main" "check"]}

--- a/dev/bench.clj
+++ b/dev/bench.clj
@@ -19,22 +19,24 @@
 
 (defn -main
   [& _args]
-  (println "=== uap-clj benchmarks ===\n")
+  (let [known-ua   (first sample-uas)
+        unknown-ua (last sample-uas)]
+    (println "=== uap-clj benchmarks ===\n")
 
-  (println "--- browser (single UA) ---")
-  (crit/quick-bench (browser (first sample-uas)))
+    (println "--- browser (single UA) ---")
+    (crit/quick-bench (browser known-ua))
 
-  (println "\n--- os (single UA) ---")
-  (crit/quick-bench (os (first sample-uas)))
+    (println "\n--- os (single UA) ---")
+    (crit/quick-bench (os known-ua))
 
-  (println "\n--- device (single UA) ---")
-  (crit/quick-bench (device (first sample-uas)))
+    (println "\n--- device (single UA) ---")
+    (crit/quick-bench (device known-ua))
 
-  (println "\n--- useragent (single UA, all fields) ---")
-  (crit/quick-bench (useragent (first sample-uas)))
+    (println "\n--- useragent (single UA, all fields) ---")
+    (crit/quick-bench (useragent known-ua))
 
-  (println "\n--- useragent (batch of 5 UAs) ---")
-  (crit/quick-bench (mapv useragent sample-uas))
+    (println "\n--- useragent (batch of 5 UAs) ---")
+    (crit/quick-bench (mapv useragent sample-uas))
 
-  (println "\n--- browser (unknown UA) ---")
-  (crit/quick-bench (browser (last sample-uas))))
+    (println "\n--- browser (unknown UA) ---")
+    (crit/quick-bench (browser unknown-ua))))

--- a/dev/bench.clj
+++ b/dev/bench.clj
@@ -22,19 +22,19 @@
   (println "=== uap-clj benchmarks ===\n")
 
   (println "--- browser (single UA) ---")
-  (crit/bench (browser (first sample-uas)))
+  (crit/quick-bench (browser (first sample-uas)))
 
   (println "\n--- os (single UA) ---")
-  (crit/bench (os (first sample-uas)))
+  (crit/quick-bench (os (first sample-uas)))
 
   (println "\n--- device (single UA) ---")
-  (crit/bench (device (first sample-uas)))
+  (crit/quick-bench (device (first sample-uas)))
 
   (println "\n--- useragent (single UA, all fields) ---")
-  (crit/bench (useragent (first sample-uas)))
+  (crit/quick-bench (useragent (first sample-uas)))
 
   (println "\n--- useragent (batch of 5 UAs) ---")
-  (crit/bench (mapv useragent sample-uas))
+  (crit/quick-bench (mapv useragent sample-uas))
 
   (println "\n--- browser (unknown UA) ---")
-  (crit/bench (browser (last sample-uas))))
+  (crit/quick-bench (browser (last sample-uas))))

--- a/dev/bench.clj
+++ b/dev/bench.clj
@@ -1,0 +1,40 @@
+(ns bench
+  "Benchmark suite for uap-clj using criterium.
+   Run with: clojure -M:bench"
+  (:require
+   [criterium.core :as crit]
+   [uap-clj.browser :refer [browser]]
+   [uap-clj.core :refer [useragent]]
+   [uap-clj.device :refer [device]]
+   [uap-clj.os :refer [os]]))
+
+
+(def sample-uas
+  ["Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+   "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+   "Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.6099.43 Mobile Safari/537.36"
+   "Lenovo-A288t_TD/S100 Linux/2.6.35 Android/2.3.5 Release/02.29.2012 Browser/AppleWebkit533.1 Mobile Safari/533.1 FlyFlow/1.4"
+   "Unknown new useragent in the wild/v0.1.0"])
+
+
+(defn -main
+  [& _args]
+  (println "=== uap-clj benchmarks ===\n")
+
+  (println "--- browser (single UA) ---")
+  (crit/bench (browser (first sample-uas)))
+
+  (println "\n--- os (single UA) ---")
+  (crit/bench (os (first sample-uas)))
+
+  (println "\n--- device (single UA) ---")
+  (crit/bench (device (first sample-uas)))
+
+  (println "\n--- useragent (single UA, all fields) ---")
+  (crit/bench (useragent (first sample-uas)))
+
+  (println "\n--- useragent (batch of 5 UAs) ---")
+  (crit/bench (mapv useragent sample-uas))
+
+  (println "\n--- browser (unknown UA) ---")
+  (crit/bench (browser (last sample-uas))))

--- a/src/uap_clj/spec.clj
+++ b/src/uap_clj/spec.clj
@@ -34,7 +34,7 @@
 
 
 ;; Full useragent result
-(s/def ::ua string?)
+(s/def ::ua (s/nilable string?))
 
 
 (s/def ::useragent

--- a/src/uap_clj/spec.clj
+++ b/src/uap_clj/spec.clj
@@ -1,0 +1,41 @@
+(ns uap-clj.spec
+  "clojure.spec definitions for uap-clj parsed output"
+  (:require
+   [clojure.spec.alpha :as s]))
+
+
+;; Shared field specs: version components are strings or nil
+(s/def ::family (s/nilable string?))
+(s/def ::major (s/nilable string?))
+(s/def ::minor (s/nilable string?))
+(s/def ::patch (s/nilable string?))
+
+
+;; Browser result
+(s/def ::browser
+  (s/keys :req-un [::family ::major ::minor ::patch]))
+
+
+;; OS result
+(s/def ::patch_minor (s/nilable string?))
+
+
+(s/def ::os
+  (s/keys :req-un [::family ::major ::minor ::patch ::patch_minor]))
+
+
+;; Device result
+(s/def ::brand (s/nilable string?))
+(s/def ::model (s/nilable string?))
+
+
+(s/def ::device
+  (s/keys :req-un [::family ::brand ::model]))
+
+
+;; Full useragent result
+(s/def ::ua string?)
+
+
+(s/def ::useragent
+  (s/keys :req-un [::ua ::browser ::os ::device]))

--- a/test/uap_clj/spec_test.clj
+++ b/test/uap_clj/spec_test.clj
@@ -7,15 +7,12 @@
    [uap-clj.core :refer [useragent]]
    [uap-clj.device :refer [device]]
    [uap-clj.os :refer [os]]
-   [uap-clj.spec]))
+   [uap-clj.spec]
+   [uap-clj.test-helpers :refer [unknown-ua]]))
 
 
 (def chrome-ua
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
-
-
-(def unknown-ua
-  "Unknown new useragent in the wild/v0.1.0")
 
 
 (deftest browser-spec-test
@@ -31,18 +28,24 @@
   (testing "known OS conforms to ::os spec"
     (is (s/valid? :uap-clj.spec/os (os chrome-ua))))
   (testing "unknown OS conforms to ::os spec"
-    (is (s/valid? :uap-clj.spec/os (os unknown-ua)))))
+    (is (s/valid? :uap-clj.spec/os (os unknown-ua))))
+  (testing "nil input conforms to ::os spec"
+    (is (s/valid? :uap-clj.spec/os (os nil)))))
 
 
 (deftest device-spec-test
   (testing "known device conforms to ::device spec"
     (is (s/valid? :uap-clj.spec/device (device chrome-ua))))
   (testing "unknown device conforms to ::device spec"
-    (is (s/valid? :uap-clj.spec/device (device unknown-ua)))))
+    (is (s/valid? :uap-clj.spec/device (device unknown-ua))))
+  (testing "nil input conforms to ::device spec"
+    (is (s/valid? :uap-clj.spec/device (device nil)))))
 
 
 (deftest useragent-spec-test
   (testing "full useragent result conforms to ::useragent spec"
     (is (s/valid? :uap-clj.spec/useragent (useragent chrome-ua))))
   (testing "unknown useragent conforms to ::useragent spec"
-    (is (s/valid? :uap-clj.spec/useragent (useragent unknown-ua)))))
+    (is (s/valid? :uap-clj.spec/useragent (useragent unknown-ua))))
+  (testing "nil input conforms to ::useragent spec"
+    (is (s/valid? :uap-clj.spec/useragent (useragent nil)))))

--- a/test/uap_clj/spec_test.clj
+++ b/test/uap_clj/spec_test.clj
@@ -1,0 +1,48 @@
+(ns uap-clj.spec-test
+  "Tests for clojure.spec definitions"
+  (:require
+   [clojure.spec.alpha :as s]
+   [clojure.test :refer [deftest is testing]]
+   [uap-clj.browser :refer [browser]]
+   [uap-clj.core :refer [useragent]]
+   [uap-clj.device :refer [device]]
+   [uap-clj.os :refer [os]]
+   [uap-clj.spec]))
+
+
+(def chrome-ua
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+
+
+(def unknown-ua
+  "Unknown new useragent in the wild/v0.1.0")
+
+
+(deftest browser-spec-test
+  (testing "known browser conforms to ::browser spec"
+    (is (s/valid? :uap-clj.spec/browser (browser chrome-ua))))
+  (testing "unknown browser conforms to ::browser spec"
+    (is (s/valid? :uap-clj.spec/browser (browser unknown-ua))))
+  (testing "nil input conforms to ::browser spec"
+    (is (s/valid? :uap-clj.spec/browser (browser nil)))))
+
+
+(deftest os-spec-test
+  (testing "known OS conforms to ::os spec"
+    (is (s/valid? :uap-clj.spec/os (os chrome-ua))))
+  (testing "unknown OS conforms to ::os spec"
+    (is (s/valid? :uap-clj.spec/os (os unknown-ua)))))
+
+
+(deftest device-spec-test
+  (testing "known device conforms to ::device spec"
+    (is (s/valid? :uap-clj.spec/device (device chrome-ua))))
+  (testing "unknown device conforms to ::device spec"
+    (is (s/valid? :uap-clj.spec/device (device unknown-ua)))))
+
+
+(deftest useragent-spec-test
+  (testing "full useragent result conforms to ::useragent spec"
+    (is (s/valid? :uap-clj.spec/useragent (useragent chrome-ua))))
+  (testing "unknown useragent conforms to ::useragent spec"
+    (is (s/valid? :uap-clj.spec/useragent (useragent unknown-ua)))))


### PR DESCRIPTION
## Summary

Adds a benchmark suite and `clojure.spec` definitions for all parsed output, plus dependency and README improvements.

## Changes

### Benchmark suite
- **`dev/bench.clj`**: [criterium](https://github.com/hugoduncan/criterium) benchmarks for `browser`, `os`, `device`, and `useragent` lookups (single UA, batch of 5, unknown UA)
- **`deps.edn`**: `:bench` alias — run with `clojure -M:bench`
- Uses `quick-bench` for fast iteration; criterium 0.5.153-ALPHA

### clojure.spec definitions
- **`src/uap_clj/spec.clj`**: specs for `::browser`, `::os`, `::device`, and `::useragent` output maps; all fields nilable to match actual library behavior (including nil input)
- **`test/uap_clj/spec_test.clj`**: conformance tests for known, unknown, and nil inputs across all parsers; reuses shared `unknown-ua` fixture from `test-helpers`

### Housekeeping
- **`deps.edn`**: bump criterium 0.4.6 → 0.5.153-ALPHA
- **`README.md`**: move Clojars badge next to CI badge at top; switch badge URLs to HTTPS; document benchmarks and specs sections; clear Future list

## Test results

```
21 tests, 113,873 assertions, 0 failures
```
