### PR TITLE
Admin follow-up: fix native-image workflow and README badges

### DIFF
--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -32,7 +32,8 @@ jobs:
     - uses: graalvm/setup-graalvm@v1
       with:
         java-version: '21'
-        distribution: 'graalce'
+        distribution: 'graalvm-community'
+        github-token: ${{ secrets.GITHUB_TOKEN }}
         native-image-job-reports: 'true'
 
     - name: Install Clojure Tools

--- a/.github/workflows/native-image.yml
+++ b/.github/workflows/native-image.yml
@@ -5,6 +5,11 @@ on:
     types:
       - published
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to attach binaries to (e.g. v1.9.0)'
+        required: false
+        type: string
 
 permissions:
   contents: write
@@ -68,9 +73,10 @@ jobs:
         path: target/uap-clj
 
     - name: Upload to release
-      if: github.event_name == 'release'
+      if: github.event_name == 'release' || inputs.tag != ''
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.event.release.tag_name || inputs.tag }}
       run: |
         cp target/uap-clj target/${{ matrix.artifact }}
-        gh release upload ${{ github.event.release.tag_name }} target/${{ matrix.artifact }} --clobber
+        gh release upload "$TAG" target/${{ matrix.artifact }} --clobber

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # uap-clj
 
 [![CI](https://github.com/russellwhitaker/uap-clj/actions/workflows/clojure.yml/badge.svg)](https://github.com/russellwhitaker/uap-clj/actions/workflows/clojure.yml)
+<br>
 [![Clojars Project](https://clojars.org/uap-clj/latest-version.svg)](https://clojars.org/uap-clj)
 
 A [`ua-parser/uap-core`](https://github.com/ua-parser/uap-core) based Clojure library for extracting browser, operating system, and device information from a raw useragent string.


### PR DESCRIPTION
- Fix native-image workflow: `graalce` distribution was removed from `setup-graalvm`, replaced with `graalvm-community`
- Add `github-token` parameter to `setup-graalvm` (now recommended)
- Add optional `tag` input to `workflow_dispatch` so manual runs can attach binaries to an existing release
- Stack Clojars badge below CI badge in README