### PR TITLE
Fix native-image build and add CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Build system: deps.edn + tools.build (`build.clj`)
 - Key aliases: `:dev`, `:test`, `:build`, `:bench`
 - Build tasks: `clojure -T:build test`, `clojure -T:build uber`, `clojure -T:build native-image`
-- Formatting: cljstyle (runs via pre-commit hook in `hooks/pre-commit`; install with `ln -s ../../hooks/pre-commit .git/hooks/pre-commit`)
+- Formatting: cljstyle (runs via pre-commit hook in `hooks/pre-commit`; install with `cp hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`)
 - Native image requires GraalVM with `native-image` on PATH
 
 ## Deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@
 - Build system: deps.edn + tools.build (`build.clj`)
 - Key aliases: `:dev`, `:test`, `:build`, `:bench`
 - Build tasks: `clojure -T:build test`, `clojure -T:build uber`, `clojure -T:build native-image`
-- Formatting: cljstyle (runs automatically via pre-commit hook on staged `.clj` files)
+- Formatting: cljstyle (runs via pre-commit hook in `hooks/pre-commit`; install with `ln -s ../../hooks/pre-commit .git/hooks/pre-commit`)
 - Native image requires GraalVM with `native-image` on PATH
 
 ## Deploy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# CLAUDE.md — Agent Guidelines for uap-clj
+
+## Git Workflow
+
+- **Never commit or push directly to `master`.** Always work on a feature branch.
+- Before any `git push`, verify the current branch with `git branch --show-current` and abort if on `master`.
+- Do not force-push or use `--no-verify` unless explicitly asked.
+
+## Testing
+
+- Run `clojure -T:build test` frequently — after any code change, before committing, and after merging.
+- All tests must pass before pushing.
+
+## Build & Project
+
+- Build system: deps.edn + tools.build (`build.clj`)
+- Key aliases: `:dev`, `:test`, `:build`, `:bench`
+- Build tasks: `clojure -T:build test`, `clojure -T:build uber`, `clojure -T:build native-image`
+- Formatting: cljstyle (runs automatically via pre-commit hook on staged `.clj` files)
+- Native image requires GraalVM with `native-image` on PATH
+
+## Deploy
+
+- Clojars deploy requires `-Djava.net.preferIPv4Stack=true` (already in `:build` alias JVM opts)
+- Use `clojure -T:build deploy` to publish to Clojars

--- a/src/uap_clj/core.clj
+++ b/src/uap_clj/core.clj
@@ -3,7 +3,7 @@
   (:gen-class)
   (:require
    [clojure.java.io :as io]
-   [clojure.string :as s :refer [join trim]]
+   [clojure.string :as s :refer [join]]
    [uap-clj.browser :refer [browser]]
    [uap-clj.common :as common :refer :all]
    [uap-clj.conf :refer [load-config]]
@@ -51,13 +51,15 @@
    'useragent_lookup.tsv' is the name of the default output file.
   "
   [in-file & opt-args]
-  (with-open [rdr (clojure.java.io/reader in-file)]
+  (with-open [rdr (io/reader in-file)]
     (let [out-file (or (first opt-args)
                        (:output-filename cfg))
           results (doall
                    (map useragent (line-seq rdr)))]
       (with-open
-       [wtr (clojure.java.io/writer out-file :append false)]
+       ;; Type hints must be per-call: with-open macro expansion drops
+       ;; binding-level hints, causing reflection failures in native-image.
+       [wtr (io/writer out-file :append false)]
         (.write ^java.io.Writer wtr header)
         (doseq [ua results]
           (.write ^java.io.Writer wtr

--- a/src/uap_clj/core.clj
+++ b/src/uap_clj/core.clj
@@ -58,9 +58,9 @@
                    (map useragent (line-seq rdr)))]
       (with-open
        [wtr (clojure.java.io/writer out-file :append false)]
-        (.write wtr header)
+        (.write ^java.io.Writer wtr (str header))
         (doseq [ua results]
-          (.write wtr
+          (.write ^java.io.Writer wtr
                   (str (s/join \tab
                                (map #(get-in ua %) columns))
                        \newline)))))))

--- a/src/uap_clj/core.clj
+++ b/src/uap_clj/core.clj
@@ -58,7 +58,7 @@
                    (map useragent (line-seq rdr)))]
       (with-open
        [wtr (clojure.java.io/writer out-file :append false)]
-        (.write ^java.io.Writer wtr (str header))
+        (.write ^java.io.Writer wtr header)
         (doseq [ua results]
           (.write ^java.io.Writer wtr
                   (str (s/join \tab


### PR DESCRIPTION
- Add `(:gen-class)` to `uap-clj.core` ns form so AOT compilation produces the class needed by native-image
- Add `^java.io.Writer` type hints to `.write` calls to fix GraalVM reflection error
- Add `CLAUDE.md` with agent operational guidelines

Note: the `macos-13` runner removal and `graalvm-community` distribution fix were merged in earlier PRs (#61, #62).