### PR TITLE
Fix native-image .write reflection: add ^String hint on header

### DIFF
--- a/src/uap_clj/core.clj
+++ b/src/uap_clj/core.clj
@@ -34,7 +34,7 @@
 (def columns (:output-columns cfg))
 
 
-(def header
+(def ^String header
   (str
    (s/join \tab
            (map #(s/join " " (map name (flatten %)))


### PR DESCRIPTION
## Fix native-image .write reflection failure

The `^java.io.Writer` per-call type hints added in #63 resolved the receiver type, but `Writer.write` is overloaded (`String`, `char[]`, `int`). The compiler also needs to know the **argument** type to select the correct overload.

The `header` var had no type hint, so the compiler saw `argument types: unknown` and fell back to reflection — which fails in GraalVM native-image.

### Changes

- Add `^String` type hint to the `header` var def in `core.clj`

### Verification

- `*warn-on-reflection*` now reports zero warnings for `uap-clj.core`
- Native image builds and smoke test passes locally
- All 21 tests pass (113,873 assertions)
