### PR TITLE
Add release agent skill

### DIFF
--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -34,7 +34,7 @@ This single value drives the JAR filename, POM version, git tag, and GitHub Rele
 ### 2. Run the full test suite
 
 ```sh
-clojure -T:build test
+clojure -M:test
 ```
 
 All tests must pass. Do not proceed if any fail.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -109,7 +109,7 @@ After the release, several GitHub Actions workflows will run:
 Confirm the artifact is available:
 
 ```sh
-curl -s "https://clojars.org/api/artifacts/uap-clj/uap-clj" | python3 -c "import sys,json; print(json.load(sys.stdin)['latest_release'])"
+curl -s "https://clojars.org/api/artifacts/uap-clj/uap-clj" | jq -r '.latest_release'
 ```
 
 Expected output: `X.Y.Z`

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -134,7 +134,7 @@ Check for reflection warnings:
 ```sh
 clojure -M -e "(set! *warn-on-reflection* true) (require 'uap-clj.core)" 2>&1 | grep "Reflection warning"
 ```
-This loads the namespace without invoking `-main` (which requires CLI arguments). Add type hints (`^String`, `^java.io.Writer`) to resolve any warnings. See the comments in `src/uap_clj/core.clj` (lines 60-61) for precedent.
+This loads the namespace without invoking `-main` (which requires CLI arguments). Add type hints (`^String`, `^java.io.Writer`) to resolve any warnings. See the `with-open` native-image reflection comment in `uap-clj.core/-main` for precedent.
 
 ### Upstream release not found by native-image workflow
 The `native-image.yml` workflow polls for the upstream release (created by `sync-upstream.yml`) for up to 5 minutes. If `sync-upstream.yml` is slow or fails, check its run logs and re-run if needed. The native-image workflow will emit a warning and skip upstream upload if the release never appears.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: release
+description: "Release uap-clj to Clojars and GitHub. Use when bumping version, publishing a release, deploying to Clojars, creating a GitHub Release, or cutting a new version. Covers version bump, testing, Clojars deploy, tagging, GitHub Release, native-image CI verification, and upstream sync."
+compatibility: "Requires Clojure CLI, gh CLI, CLOJARS_USERNAME and CLOJARS_PASSWORD env vars, and UPSTREAM_PUSH_TOKEN GitHub secret."
+metadata:
+  author: russellwhitaker
+  version: "1.0"
+---
+
+# Release Workflow
+
+Complete procedure for releasing a new version of uap-clj.
+
+## Prerequisites
+
+- Clean working tree on a feature branch (never release from `master` directly)
+- `gh` CLI authenticated
+- `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` environment variables set
+- All tests passing
+
+## Procedure
+
+### 1. Bump the version
+
+Edit `build.clj` and update the `version` string:
+
+```clojure
+(def version "X.Y.Z")
+```
+
+This single value drives the JAR filename, POM version, git tag, and GitHub Release name.
+
+### 2. Run the full test suite
+
+```sh
+clojure -T:build test
+```
+
+All 21 tests (113,000+ assertions) must pass. Do not proceed if any fail.
+
+### 3. Check formatting
+
+```sh
+clojure -M:cljstyle-check
+```
+
+Fix any issues with `clojure -M:cljstyle-fix` before continuing.
+
+### 4. Check for outdated dependencies
+
+```sh
+clojure -T:build outdated
+```
+
+Address any critical updates before releasing.
+
+### 5. Commit the version bump
+
+```sh
+git add build.clj
+git commit -m "Bump version to X.Y.Z"
+git push origin <branch>
+```
+
+### 6. Merge to master
+
+Create a PR, get it merged, then pull master locally:
+
+```sh
+git checkout master
+git pull origin master
+```
+
+### 7. Run the release task
+
+```sh
+clojure -T:build release
+```
+
+This single command performs:
+1. **Pre-flight checks**: fetches remote tags, verifies the tag doesn't already exist
+2. **Clojars deploy**: builds the JAR and deploys to Clojars (uses `-Djava.net.preferIPv4Stack=true` from `:build` alias)
+3. **Git tag**: creates annotated tag `vX.Y.Z`
+4. **Push tag**: pushes the tag to origin
+5. **GitHub Release**: creates a release with a changelog link
+
+### 8. Verify CI workflows
+
+After the release is published, three GitHub Actions workflows trigger automatically:
+
+#### Upstream sync (`sync-upstream.yml`)
+- Mirrors the tag and GitHub Release to `ua-parser/uap-clj`
+- Check: `gh api repos/ua-parser/uap-clj/releases/tags/vX.Y.Z --jq '.html_url'`
+
+#### Native image (`native-image.yml`)
+- Builds binaries for Linux (amd64) and macOS (arm64)
+- Uploads them to the GitHub Release on both origin and upstream
+- Polls up to 5 minutes for the upstream release to appear
+- Check: look for `uap-clj-linux-amd64` and `uap-clj-macos-arm64` assets on the release page
+
+#### CI (`clojure.yml`)
+- Runs tests, formatting check, and outdated check against the new master
+- Should pass (you already verified locally)
+
+### 9. Verify Clojars
+
+Confirm the artifact is available:
+
+```sh
+curl -s "https://clojars.org/api/artifacts/uap-clj/uap-clj" | python3 -c "import sys,json; print(json.load(sys.stdin)['latest_release'])"
+```
+
+Expected output: `X.Y.Z`
+
+## Troubleshooting
+
+### Clojars deploy fails with "Broken pipe"
+The `:build` alias already includes `-Djava.net.preferIPv4Stack=true` in its JVM opts. If you still see this, verify the setting is present in `deps.edn` under `:build :jvm-opts`.
+
+### Tag already exists
+The release task checks for existing tags before deploying. If you need to re-release, delete the tag first:
+```sh
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+```
+Then also delete the GitHub Release via the web UI or `gh release delete vX.Y.Z`.
+
+### Native image build fails with reflection errors
+Check for reflection warnings:
+```sh
+clojure -e "(set! *warn-on-reflection* true)" -M -m uap-clj.core 2>&1 | grep "Reflection warning"
+```
+Add type hints (`^String`, `^java.io.Writer`) to resolve. See PR #64 for precedent.
+
+### Upstream release not found by native-image workflow
+The `native-image.yml` workflow polls for the upstream release (created by `sync-upstream.yml`) for up to 5 minutes. If `sync-upstream.yml` is slow or fails, check its run logs and re-run if needed. The native-image workflow will emit a warning and skip upstream upload if the release never appears.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: "Release uap-clj to Clojars and GitHub. Use when bumping version, publishing a release, deploying to Clojars, creating a GitHub Release, or cutting a new version. Covers version bump, testing, Clojars deploy, tagging, GitHub Release, native-image CI verification, and upstream sync."
-compatibility: "Requires Clojure CLI, gh CLI, jq, CLOJARS_USERNAME and CLOJARS_PASSWORD env vars, and UPSTREAM_PUSH_TOKEN GitHub secret."
+compatibility: "Requires Clojure CLI, gh CLI, jq, CLOJARS_USERNAME and CLOJARS_PASSWORD env vars. UPSTREAM_PUSH_TOKEN GitHub secret is needed only for post-release upstream mirroring (sync-upstream/native-image workflows)."
 metadata:
   author: russellwhitaker
   version: "1.0"

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -37,7 +37,7 @@ This single value drives the JAR filename, POM version, git tag, and GitHub Rele
 clojure -T:build test
 ```
 
-All 21 tests (113,000+ assertions) must pass. Do not proceed if any fail.
+All tests must pass. Do not proceed if any fail.
 
 ### 3. Check formatting
 

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: "Release uap-clj to Clojars and GitHub. Use when bumping version, publishing a release, deploying to Clojars, creating a GitHub Release, or cutting a new version. Covers version bump, testing, Clojars deploy, tagging, GitHub Release, native-image CI verification, and upstream sync."
-compatibility: "Requires Clojure CLI, gh CLI, CLOJARS_USERNAME and CLOJARS_PASSWORD env vars, and UPSTREAM_PUSH_TOKEN GitHub secret."
+compatibility: "Requires Clojure CLI, gh CLI, jq, CLOJARS_USERNAME and CLOJARS_PASSWORD env vars, and UPSTREAM_PUSH_TOKEN GitHub secret."
 metadata:
   author: russellwhitaker
   version: "1.0"
@@ -16,7 +16,9 @@ Complete procedure for releasing a new version of uap-clj.
 - Version bump done on a feature branch via PR (never commit directly to `master`)
 - Clean working tree on `master` after the version-bump PR is merged
 - `gh` CLI authenticated
+- `jq` installed (used for Clojars verification)
 - `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` environment variables set
+- uap-core submodule initialized (`git submodule update --init --recursive`)
 - All tests passing
 
 ## Procedure
@@ -83,7 +85,7 @@ This single command performs:
 2. **Clojars deploy**: builds the JAR and deploys to Clojars (uses `-Djava.net.preferIPv4Stack=true` from `:build` alias)
 3. **Git tag**: creates annotated tag `vX.Y.Z`
 4. **Push tag**: pushes the tag to origin
-5. **GitHub Release**: creates a release with a changelog link
+5. **GitHub Release**: creates a release (includes a "Full Changelog" compare link when a previous tag exists; otherwise uses a plain "Release vX.Y.Z" body)
 
 ### 8. Verify CI and post-release workflows
 
@@ -132,7 +134,7 @@ Check for reflection warnings:
 ```sh
 clojure -M -e "(set! *warn-on-reflection* true) (require 'uap-clj.core)" 2>&1 | grep "Reflection warning"
 ```
-This loads the namespace without invoking `-main` (which requires CLI arguments). Add type hints (`^String`, `^java.io.Writer`) to resolve any warnings. See PR #64 for precedent.
+This loads the namespace without invoking `-main` (which requires CLI arguments). Add type hints (`^String`, `^java.io.Writer`) to resolve any warnings. See the comments in `src/uap_clj/core.clj` (lines 60-61) for precedent.
 
 ### Upstream release not found by native-image workflow
 The `native-image.yml` workflow polls for the upstream release (created by `sync-upstream.yml`) for up to 5 minutes. If `sync-upstream.yml` is slow or fails, check its run logs and re-run if needed. The native-image workflow will emit a warning and skip upstream upload if the release never appears.

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: release
 description: "Release uap-clj to Clojars and GitHub. Use when bumping version, publishing a release, deploying to Clojars, creating a GitHub Release, or cutting a new version. Covers version bump, testing, Clojars deploy, tagging, GitHub Release, native-image CI verification, and upstream sync."
-compatibility: "Requires Clojure CLI, gh CLI, jq, CLOJARS_USERNAME and CLOJARS_PASSWORD env vars. UPSTREAM_PUSH_TOKEN GitHub secret is needed only for post-release upstream mirroring (sync-upstream/native-image workflows)."
+compatibility: "Requires Clojure CLI, git, gh CLI, curl, jq, CLOJARS_USERNAME and CLOJARS_PASSWORD env vars. UPSTREAM_PUSH_TOKEN GitHub secret is needed only for post-release upstream mirroring (sync-upstream/native-image workflows)."
 metadata:
   author: russellwhitaker
   version: "1.0"

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -85,9 +85,14 @@ This single command performs:
 4. **Push tag**: pushes the tag to origin
 5. **GitHub Release**: creates a release with a changelog link
 
-### 8. Verify CI workflows
+### 8. Verify CI and post-release workflows
 
-After the release, several GitHub Actions workflows will run:
+#### CI (`clojure.yml`) — already ran on merge to `master`
+- Triggered when the version-bump PR was merged (push to `master`)
+- Runs tests, formatting check, and outdated check
+- Should have passed (you already verified locally in steps 2-4)
+
+After the release task creates the GitHub Release, two additional workflows trigger:
 
 #### Upstream sync (`sync-upstream.yml`) — triggers on `release: published`
 - Mirrors the tag and GitHub Release to `ua-parser/uap-clj`
@@ -98,11 +103,6 @@ After the release, several GitHub Actions workflows will run:
 - Uploads them to the GitHub Release on both origin and upstream
 - Polls up to 5 minutes for the upstream release to appear
 - Check: look for `uap-clj-linux-amd64` and `uap-clj-macos-arm64` assets on the release page
-
-#### CI (`clojure.yml`) — triggers on push to `master`
-- Already ran when the version-bump PR was merged
-- Runs tests, formatting check, and outdated check
-- Should pass (you already verified locally in steps 2-4)
 
 ### 9. Verify Clojars
 

--- a/.github/skills/release/SKILL.md
+++ b/.github/skills/release/SKILL.md
@@ -13,7 +13,8 @@ Complete procedure for releasing a new version of uap-clj.
 
 ## Prerequisites
 
-- Clean working tree on a feature branch (never release from `master` directly)
+- Version bump done on a feature branch via PR (never commit directly to `master`)
+- Clean working tree on `master` after the version-bump PR is merged
 - `gh` CLI authenticated
 - `CLOJARS_USERNAME` and `CLOJARS_PASSWORD` environment variables set
 - All tests passing
@@ -86,21 +87,22 @@ This single command performs:
 
 ### 8. Verify CI workflows
 
-After the release is published, three GitHub Actions workflows trigger automatically:
+After the release, several GitHub Actions workflows will run:
 
-#### Upstream sync (`sync-upstream.yml`)
+#### Upstream sync (`sync-upstream.yml`) — triggers on `release: published`
 - Mirrors the tag and GitHub Release to `ua-parser/uap-clj`
 - Check: `gh api repos/ua-parser/uap-clj/releases/tags/vX.Y.Z --jq '.html_url'`
 
-#### Native image (`native-image.yml`)
+#### Native image (`native-image.yml`) — triggers on `release: published`
 - Builds binaries for Linux (amd64) and macOS (arm64)
 - Uploads them to the GitHub Release on both origin and upstream
 - Polls up to 5 minutes for the upstream release to appear
 - Check: look for `uap-clj-linux-amd64` and `uap-clj-macos-arm64` assets on the release page
 
-#### CI (`clojure.yml`)
-- Runs tests, formatting check, and outdated check against the new master
-- Should pass (you already verified locally)
+#### CI (`clojure.yml`) — triggers on push to `master`
+- Already ran when the version-bump PR was merged
+- Runs tests, formatting check, and outdated check
+- Should pass (you already verified locally in steps 2-4)
 
 ### 9. Verify Clojars
 
@@ -128,9 +130,9 @@ Then also delete the GitHub Release via the web UI or `gh release delete vX.Y.Z`
 ### Native image build fails with reflection errors
 Check for reflection warnings:
 ```sh
-clojure -e "(set! *warn-on-reflection* true)" -M -m uap-clj.core 2>&1 | grep "Reflection warning"
+clojure -M -e "(set! *warn-on-reflection* true) (require 'uap-clj.core)" 2>&1 | grep "Reflection warning"
 ```
-Add type hints (`^String`, `^java.io.Writer`) to resolve. See PR #64 for precedent.
+This loads the namespace without invoking `-main` (which requires CLI arguments). Add type hints (`^String`, `^java.io.Writer`) to resolve any warnings. See PR #64 for precedent.
 
 ### Upstream release not found by native-image workflow
 The `native-image.yml` workflow polls for the upstream release (created by `sync-upstream.yml`) for up to 5 minutes. If `sync-upstream.yml` is slow or fails, check its run logs and re-run if needed. The native-image workflow will emit a warning and skip upstream upload if the release never appears.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,3 +23,7 @@
 
 - Clojars deploy requires `-Djava.net.preferIPv4Stack=true` (already in `:build` alias JVM opts)
 - Use `clojure -T:build deploy` to publish to Clojars
+
+## Skills
+
+- Release workflow: `.github/skills/release/SKILL.md`

--- a/README.md
+++ b/README.md
@@ -96,6 +96,16 @@ $ clojure -M:bench
 
 This benchmarks `browser`, `os`, `device`, and `useragent` lookups individually and in batch.
 
+### Agent Skills
+
+This project includes [Agent Skills](https://agentskills.io/) — machine-readable workflow instructions that AI coding agents (Claude Code, VS Code Copilot, Roo Code, and others) discover and follow automatically. Skills live in `.github/skills/` and encode project-specific procedural knowledge so agents can execute complex workflows (like releasing to Clojars) without manual prompting.
+
+Available skills:
+
+| Skill | Description |
+|-------|-------------|
+| [`release`](.github/skills/release/SKILL.md) | Full release workflow: version bump, testing, Clojars deploy, tagging, GitHub Release, and post-release CI verification |
+
 ### Specs
 
 `clojure.spec` definitions for all parsed output maps are available in `uap-clj.spec`. To use them:


### PR DESCRIPTION
Add an [Agent Skills](https://agentskills.io/) `release` skill at `.github/skills/release/SKILL.md`.

### What is an Agent Skill?

Agent Skills are an [open standard](https://agentskills.io/) for packaging domain-specific procedural knowledge so that AI coding agents (Claude Code, VS Code Copilot, Roo Code, and others) can discover and follow project-specific workflows automatically. When an agent detects a task matching a skill's description, it loads the skill's step-by-step instructions — no manual prompting required.

### Why a release skill?

Releasing uap-clj involves a multi-step process with project-specific details that are easy to miss: IPv4 workarounds for Clojars, tag pre-flight checks in `build.clj`, conditional changelog bodies, post-release CI workflows that mirror to the upstream `ua-parser/uap-clj` fork, and native-image binary uploads that depend on a polling/retry loop. Encoding this knowledge as a skill means an agent can execute the full release workflow correctly without the maintainer needing to spell it out every time.

### What the skill covers

1. Version bump in `build.clj`
2. Test suite and formatting verification
3. Clojars deploy (with IPv4 workaround notes)
4. Git tagging and GitHub Release creation (including conditional changelog behavior)
5. Post-release CI verification (native-image builds, upstream sync)
6. Troubleshooting common issues (Broken pipe, reflection errors, tag conflicts, upstream race conditions)

The skill uses progressive disclosure — agents read the `name` and `description` metadata first, then load the full procedure only when a release task is detected.

### Changes

- `.github/skills/release/SKILL.md` — new release skill following the agentskills.io format
- `CLAUDE.md` — reference to the release skill
- `README.md` — mention of Agent Skills in the Development section
